### PR TITLE
Features/no initial soc for storages

### DIFF
--- a/oemof/core/network/entities/components/transformers.py
+++ b/oemof/core/network/entities/components/transformers.py
@@ -1,4 +1,3 @@
-
 from . import Transformer
 import logging
 import numpy as np
@@ -128,8 +127,8 @@ class Storage(Transformer):
         absolut maximum state of charge of built capacity if invest=TRUE
     cap_min : float
         absolut minimum state of charge
-    cap_initial : float
-        state of charge at timestep 0 (default cap_max*0.5)
+    cap_initial : float, optional
+        The state of charge (soc) at timestep 0.
     add_cap_limit : float
         limit of additional installed capacity (only investment models)
     eta_in : float
@@ -153,10 +152,6 @@ class Storage(Transformer):
         self.cap_min = kwargs.get('cap_min', None)
         self.add_cap_limit = kwargs.get('add_cap_limit', None)
         self.cap_initial = kwargs.get('cap_initial', None)
-        if self.cap_initial is None:
-            self.cap_initial = self.cap_max*0.5
-            logging.info('No initial storage capacity set. Setting capacity ' +
-                         'to 0.5 of max. capacity for component: %s', self.uid)
         self.eta_in = kwargs.get('eta_in', 1)
         self.eta_out = kwargs.get('eta_out', 1)
         self.cap_loss = kwargs.get('cap_loss', 0)

--- a/oemof/solph/linear_constraints.py
+++ b/oemof/solph/linear_constraints.py
@@ -549,7 +549,7 @@ def add_storage_balance(model, block):
         if(t == 0):
             t_last = len(model.timesteps)-1
             expr += block.cap[e, t]
-            expr += - block.cap[e, t_last] #* (1 - cap_loss[e])
+            expr += - block.cap[e, t_last] * (1 - cap_loss[e])
             expr += - model.w[model.I[e], e, t] * eta_in[e]
             expr += + model.w[e, model.O[e][0], t] / eta_out[e]
         else:

--- a/oemof/solph/linear_constraints.py
+++ b/oemof/solph/linear_constraints.py
@@ -537,8 +537,8 @@ def add_storage_balance(model, block):
         eta_out[e.uid] = e.eta_out
 
     # set cap of last timesteps to fixed value of cap_initial
-    if cap_initial[e] is not None:
-        for e in block.uids:
+    for e in block.uids:
+        if cap_initial[e] is not None:
             block.cap[e, 0] = cap_initial[e]
             block.cap[e, 0].fix()
 

--- a/oemof/solph/linear_constraints.py
+++ b/oemof/solph/linear_constraints.py
@@ -496,6 +496,7 @@ def add_dispatch_source(model, block):
     block.curtailment = po.Constraint(block.indexset,
                                       rule=curtailment_source_rule)
 
+
 def add_storage_balance(model, block):
     """ Constraint to build the storage balance in every timestep
 
@@ -522,7 +523,7 @@ def add_storage_balance(model, block):
     """
     if not block.objs or block.objs is None:
         raise ValueError('No objects defined. Please specify objects for' +
-                          'which storage balanece constraint should be set.')
+                         'which storage balanece constraint should be set.')
     # constraint for storage energy balance
     cap_initial = {}
     cap_loss = {}
@@ -536,17 +537,18 @@ def add_storage_balance(model, block):
         eta_out[e.uid] = e.eta_out
 
     # set cap of last timesteps to fixed value of cap_initial
-    t_last = len(model.timesteps)-1
-    for e in block.uids:
-      block.cap[e, t_last] = cap_initial[e]
-      block.cap[e, t_last].fix()
+    if cap_initial[e] is not None:
+        for e in block.uids:
+            block.cap[e, 0] = cap_initial[e]
+            block.cap[e, 0].fix()
 
     def storage_balance_rule(block, e, t):
-        # TODO:
-        #   - include time increment
+        # TODO: include time increment
         expr = 0
         if(t == 0):
-            expr += block.cap[e, t] - cap_initial[e]
+            t_last = len(model.timesteps)-1
+            expr += block.cap[e, t]
+            expr += - block.cap[e, t_last] * (1 - cap_loss[e])
             expr += - model.w[model.I[e], e, t] * eta_in[e]
             expr += + model.w[e, model.O[e][0], t] / eta_out[e]
         else:

--- a/oemof/solph/linear_constraints.py
+++ b/oemof/solph/linear_constraints.py
@@ -537,10 +537,11 @@ def add_storage_balance(model, block):
         eta_out[e.uid] = e.eta_out
 
     # set cap of last timesteps to fixed value of cap_initial
+    t_last = len(model.timesteps)-1
     for e in block.uids:
         if cap_initial[e] is not None:
-            block.cap[e, 0] = cap_initial[e]
-            block.cap[e, 0].fix()
+            block.cap[e, t_last] = cap_initial[e]
+            block.cap[e, t_last].fix()
 
     def storage_balance_rule(block, e, t):
         # TODO: include time increment
@@ -548,7 +549,7 @@ def add_storage_balance(model, block):
         if(t == 0):
             t_last = len(model.timesteps)-1
             expr += block.cap[e, t]
-            expr += - block.cap[e, t_last] * (1 - cap_loss[e])
+            expr += - block.cap[e, t_last] #* (1 - cap_loss[e])
             expr += - model.w[model.I[e], e, t] * eta_in[e]
             expr += + model.w[e, model.O[e][0], t] / eta_out[e]
         else:


### PR DESCRIPTION
As I understand it the first and the last values of the state of charge of storages are already forced to be the same by a constraint. But it is still obligate to define an initial state of charge. I would like to make it optional.
