### PR TITLE
heatstorage with dT

### DIFF
--- a/oemof/core/network/entities/buses/__init__.py
+++ b/oemof/core/network/entities/buses/__init__.py
@@ -1,0 +1,16 @@
+from .. import Bus
+from
+
+
+class HeatBuse(Bus):
+    r"""
+    Parameters
+    ----------
+    temp_kelvin : float or array-like
+        Temperature of the Bus
+
+    """
+
+    def __init__(self, temp_kelvin, **kwargs):
+        super().__init__(**kwargs)
+        self.temp_kelvin = temp_kelvin

--- a/oemof/core/network/entities/buses/__init__.py
+++ b/oemof/core/network/entities/buses/__init__.py
@@ -1,8 +1,7 @@
 from .. import Bus
-from
 
 
-class HeatBuse(Bus):
+class HeatBus(Bus):
     r"""
     Parameters
     ----------

--- a/oemof/core/network/entities/components/transformers.py
+++ b/oemof/core/network/entities/components/transformers.py
@@ -24,6 +24,13 @@ class Simple(Transformer):
         self.eta = kwargs.get('eta', None)
 
 
+class PostHeating(Simple):
+    r"""
+    """
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
 class CHP(Transformer):
     """
     A CombinedHeatPower Transformer always has a simple input output relation

--- a/oemof/solph/optimization_model.py
+++ b/oemof/solph/optimization_model.py
@@ -16,7 +16,8 @@ from . import linear_constraints as lc
 from ..core.network.entities import Bus, Component
 from ..core.network.entities import components as cp
 from ..core.network.entities.components.transformers import (
-    CHP, Simple, SimpleExtractionCHP, Storage, VariableEfficiencyCHP)
+    CHP, Simple, SimpleExtractionCHP, Storage, VariableEfficiencyCHP,
+    PostHeating)
 from ..core.network.entities.components.sources import (
     Commodity, DispatchSource, FixedSource)
 from ..core.network.entities.components.sinks import Simple as Sink
@@ -488,6 +489,37 @@ def _(e, om, block):
     def linear_constraints(om, block):
         lc.add_simple_io_relation(om, block)
         var.set_bounds(om, block, side="output")
+
+    block.default_optimization_options = {
+        "linear_constr": linear_constraints}
+
+    om.default_assembler(block)
+    return om
+
+
+@assembler.register(PostHeating)
+def _(e, om, block):
+    """ Method containing the constraints functions for simple
+    transformer components.
+
+    Constraints are selected by the `optimization_options` variable of
+    :class:`Simple`.
+
+    Parameters
+    ----------
+    see :func:`assembler`.
+
+    Returns
+    -------
+    see :func:`assembler`.
+    """
+    # TODO: This should be dependent on objs classes not fixed if assembler
+    # method is used by another assemlber method...
+
+    def linear_constraints(om, block):
+        lc.add_simple_io_relation(om, block)
+        var.set_bounds(om, block, side="output")
+        lc.add_postheat_relation(om, block)
 
     block.default_optimization_options = {
         "linear_constr": linear_constraints}


### PR DESCRIPTION
The aim of this feature is a heat storage that might have a different temperature level than the bus it is connected to. Therefore it needs an additional device to heat up the heat carrier to the bus level if the temperature of the bus is higher than the temperature of the storage.

With the first commit (eb224db) a new bus class was created named HeatBus that has an attribute for the temperature.