### PR TITLE
Refactor the PostHeating class and its solph functions

### DIFF
--- a/doc/whatsnew/v0-0-5.rst
+++ b/doc/whatsnew/v0-0-5.rst
@@ -4,7 +4,7 @@ v0.0.5 (DATE)
 New features
 ############
 
-* 
+* added flexible transformer with two inputs and one output (`issue #116 <https://github.com/oemof/oemof_base/issues/116>`_)
 
 Documentation
 #############

--- a/oemof/core/network/entities/components/transformers.py
+++ b/oemof/core/network/entities/components/transformers.py
@@ -23,18 +23,27 @@ class Simple(Transformer):
         self.eta = kwargs.get('eta', None)
 
 
-class PostHeating(Simple):
+class TwoInputsOneOutput(Simple):
     r"""
-    A postheating transformer can transport heat from one HeatBus to another
-    eventhough the temperature levels are different.
+    A transformer with one output and two input flows
 
-    The postheating transformer needs an two buses containing the temperature
-    attribute as an input and an output. Another nergy input is used to heat up
-    the heat flow if the temperature in the output bus is lower. In the list
-    of inputs the additional bus is defined first and then the heat flow.
+    The two input flows are connect by the factor f. This transformer might
+    represent components such as heat pumps and instant flow heater.
+
+    Parameters
+    ----------
+    eta : list
+        Constant effciency for converting the incoming flows to the internal
+        input flows. The first element of eta is the efficiency of the first
+        element of inputs and so on. If not set the effciency will be one. You
+        have to define both elements or no element.
+    f : array-like
+        A relation-factor between the first and the second input flow.
     """
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.eta = kwargs.get('eta', [1, 1])
+        self.f = kwargs.get('f')
 
 
 class CHP(Transformer):

--- a/oemof/solph/linear_constraints.py
+++ b/oemof/solph/linear_constraints.py
@@ -137,10 +137,15 @@ def add_simple_io_relation(model, block, idx=0):
 
     eta = {obj.uid: obj.eta for obj in block.objs}
 
+    for key, value in eta.items():
+        try:
+            len(value[0])
+        except:
+            eta[key] = [[x] * len(model.timesteps) for x in value]
 
     # constraint for simple transformers: input * efficiency = output
     def io_rule(block, e, t):
-        lhs = model.w[model.I[e][0], e, t] * eta[e][idx] - \
+        lhs = model.w[model.I[e][0], e, t] * eta[e][idx][t] - \
             model.w[e, model.O[e][idx], t]
         return(lhs == 0)
 

--- a/oemof/solph/linear_constraints.py
+++ b/oemof/solph/linear_constraints.py
@@ -158,7 +158,7 @@ def add_simple_io_relation(model, block, idx=0):
                             block.indexset)
 
 
-def add_two_inputs_io_relation(model, block):
+def add_two_inputs_one_output_relation(model, block):
     r""" Adds constraint for the input-output relation of a post heating
     transformer with two input flows.
 
@@ -171,6 +171,10 @@ def add_two_inputs_io_relation(model, block):
     .. math::
         w_{e,i_{e,1}}(t)\cdot\eta_{e,i_{e,1}}(t)+w_{e,i_{e,2}}(t)\cdot
         \eta_{e,i_{e,2}}(t)=w_{e,o_{e}},\qquad\forall e,\forall t\qquad\qquad
+
+    .. math::
+        w_{e,i_{e,1}}(t)=w_{e,i_{e,2}}(t)\cdot f(t),\quad\forall e,\forall t
+        \qquad\\
 
     With :math:`e\in\mathcal{E}` and :math:`\mathcal{E}` beeing the
     set of unique ids for all entities grouped inside the
@@ -192,6 +196,7 @@ def add_two_inputs_io_relation(model, block):
                          which the constraints should be build")
 
     eta = {obj.uid: obj.eta for obj in block.objs}
+    f = {obj.uid: obj.f for obj in block.objs}
 
     # constraint for simple transformers: input * efficiency = output
     def io_rule(block, e, t):
@@ -200,17 +205,18 @@ def add_two_inputs_io_relation(model, block):
                model.w[e, model.O[e][0], t])
         return(lhs == 0)
 
-    if not model.energysystem.simulation.fast_build:
-        pass
-    block.io_relation = po.Constraint(
-            block.indexset, rule=io_rule,
-            doc="INFLOW_1 * efficiency_1 +  INFLOW_2 * efficiency_2 = OUTFLOW"
-            )
+    def two_inputs_rule(block, e, t):
+        lhs = (model.w[model.I[e][1], e, t] * eta[e][1] * f[e][t] -
+               model.w[model.I[e][0], e, t] * eta[e][0])
+        return(lhs == 0)
 
-    if model.energysystem.simulation.fast_build:
-        name = inspect.stack()[0][3]
-        logging.warning(
-            'No fastbuild constraints defined for function: {0}.'.format(name))
+    block.io_relation = po.Constraint(
+        block.indexset, rule=io_rule,
+        doc="INFLOW_1 * efficiency_1 +  INFLOW_2 * efficiency_2 = OUTFLOW")
+
+    block.two_inputs_relation = po.Constraint(
+        block.indexset, rule=two_inputs_rule,
+        doc="INFLOW_1  =  INFLOW_2 * efficiency_2 * f")
 
 
 def add_eta_total_chp_relation(model, block):
@@ -305,68 +311,6 @@ def add_simple_chp_relation(model, block):
                              for e,t in block.indexset}
         pofast.l_constraint(block, 'pth_relation', pth_relation_dict,
                             block.indexset)
-
-
-def add_postheat_relation(model, block):
-    r""" Adds constraint for the input relation of a post heating device.
-
-    The additional device of the postheat transformer will heat up the flow and
-    therefore will deliver an amount of energy. This amount depends on the
-    temperature difference between the buses and the temperature difference
-    between the input bus and the return flow temperature.
-
-    The mathematical formulation for the constraint is as follows:
-
-    .. math::
-        w_{e,i_{e,1}}(t)=w_{e,i_{e,2}}(t)\cdot f,\quad\forall e,\forall t
-        \qquad\\
-        \\
-        f=\frac{T^{flow}_{bus,o}-T^{flow}_{bus,i}}
-        {T^{flow}_{bus,i}-T^{return}_{bus,o}}\qquad\qquad\qquad
-
-    With :math:`e\in\mathcal{E}` and :math:`\mathcal{E}` beeing the
-    set of unique ids for all entities grouped inside the
-    attribute `block.objs`.
-
-    Additionally: :math:`\mathcal{E} \subset \mathcal{E}_{IIO}`.
-
-    Parameters
-    ----------
-    model : OptimizationModel() instance
-        An object to be solved containing all Variables, Constraints, Data.
-    block : SimpleBlock()
-         block to group all constraints and variables etc., block corresponds
-         to one oemof base class
-
-    """
-    if not block.objs or block.objs is None:
-        raise ValueError('No objects defined. Please specify objects for \
-                          which post heating constraints should be set.')
-
-    T_coeff = {}
-    for e in block.objs:
-        out = [o for o in e.outputs[:]]
-        T_out = out[0].temperature
-        T_re_out = out[0].re_temperature
-        T_in = [o for o in e.inputs[:]][1].temperature
-        dT_throw = T_out - T_in
-        dT_throw[dT_throw < 0] = 0
-        dT_in = T_in - T_re_out
-        T_coeff[e.uid] = (dT_throw) / (dT_in)
-
-    def postheat_rule(block, e, t):
-        lhs = (model.w[model.I[e][1], e, t] * T_coeff[e][t] -
-               model.w[model.I[e][0], e, t])
-        return(lhs == 0)
-
-    if not model.energysystem.simulation.fast_build:
-        block.postheat = po.Constraint(block.indexset, rule=postheat_rule,
-                                       doc="Q * f = P_addition")
-
-    if model.energysystem.simulation.fast_build:
-        name = inspect.stack()[0][3]
-        logging.warning(
-            'No fastbuild constraints defined for function: {0}.'.format(name))
 
 
 def add_simple_extraction_chp_relation(model, block):

--- a/oemof/solph/optimization_model.py
+++ b/oemof/solph/optimization_model.py
@@ -525,7 +525,7 @@ def _(e, om, block):
     return om
 
 
-@assembler.register(transformer.PostHeating)
+@assembler.register(transformer.TwoInputsOneOutput)
 def _(e, om, block):
     """ Method containing the constraints functions for simple
     transformer components.
@@ -545,10 +545,9 @@ def _(e, om, block):
     # method is used by another assemlber method...
 
     def linear_constraints(om, block):
-        lc.add_two_inputs_io_relation(om, block)
+        lc.add_two_inputs_one_output_relation(om, block)
         var.set_bounds(om, block, side="output")
         var.set_bounds(om, block, side="input")
-        lc.add_postheat_relation(om, block)
 
     block.default_optimization_options = {
         "linear_constr": linear_constraints}

--- a/oemof/solph/predefined_objectives.py
+++ b/oemof/solph/predefined_objectives.py
@@ -43,7 +43,7 @@ def minimize_cost(self, cost_objects=None, revenue_objects=None):
 
     if cost_objects is None:
         c_blocks = [str(transformer.Simple),
-                    str(transformer.PostHeating),
+                    str(transformer.TwoInputsOneOutput),
                     str(transformer.VariableEfficiencyCHP),
                     str(transformer.SimpleExtractionCHP),
                     str(transformer.Storage),

--- a/oemof/tools/create_components.py
+++ b/oemof/tools/create_components.py
@@ -1,0 +1,9 @@
+#!/usr/bin/python
+# -*- coding: utf-8
+
+
+def instant_flow_heater(bus_low, bus_high):
+    f = ((bus_high.temperature - bus_low.temperature) /
+         (bus_low.temperature - bus_high.re_temperature))
+    f[f < 0] = 0
+    return f

--- a/oemof/tools/helpers.py
+++ b/oemof/tools/helpers.py
@@ -292,7 +292,7 @@ def fetch_admin_from_coord_osm(coord):
 
     Examples
     --------
-    >>> fetch_admin_from_coord_osm((12.7, 51.8))
+    >>> fetch_admin_from_coord_osm((12.7, 51.8)) # doctest: +SKIP
     ['Deutschland', 'ST']
     """
 
@@ -354,8 +354,8 @@ def fetch_admin_from_coord_google(coord):
 
     Examples
     --------
-    >>> fetch_admin_from_coord_osm((12.7, 51.8))
-    ['Deutschland', 'ST']
+    >>> fetch_admin_from_coord_google((12.7, 51.8))
+    ['DE', 'SA']
     """
 
     new_coord = list((coord[1], coord[0]))

--- a/tests/lp_files/two_inputs_one_output.lp
+++ b/tests/lp_files/two_inputs_one_output.lp
@@ -5,35 +5,35 @@ objective: +0.0 ONE_VAR_CONSTANT
 
 s.t.
 
-c_e__class__oemof_core_network_entities_components_transformers_PostHeating___io_relation(postheat_elec_0)_:
+c_e__class__oemof_core_network_entities_components_transformers_TwoInputsOneOutput___io_relation(postheat_elec_0)_:
 +1 w(bus_stor_heat_postheat_elec_0)
 +0.94999999999999996 w(bus_test_postheat_elec_0)
 -1 w(postheat_elec_bus_distr_heat_0)
 = 0
 
-c_e__class__oemof_core_network_entities_components_transformers_PostHeating___io_relation(postheat_elec_1)_:
+c_e__class__oemof_core_network_entities_components_transformers_TwoInputsOneOutput___io_relation(postheat_elec_1)_:
 +1 w(bus_stor_heat_postheat_elec_1)
 +0.94999999999999996 w(bus_test_postheat_elec_1)
 -1 w(postheat_elec_bus_distr_heat_1)
 = 0
 
-c_e__class__oemof_core_network_entities_components_transformers_PostHeating___io_relation(postheat_elec_2)_:
+c_e__class__oemof_core_network_entities_components_transformers_TwoInputsOneOutput___io_relation(postheat_elec_2)_:
 +1 w(bus_stor_heat_postheat_elec_2)
 +0.94999999999999996 w(bus_test_postheat_elec_2)
 -1 w(postheat_elec_bus_distr_heat_2)
 = 0
 
-c_e__class__oemof_core_network_entities_components_transformers_PostHeating___postheat(postheat_elec_0)_:
+c_e__class__oemof_core_network_entities_components_transformers_TwoInputsOneOutput___two_inputs_relation(postheat_elec_0)_:
 +0.33333333333333331 w(bus_stor_heat_postheat_elec_0)
--1 w(bus_test_postheat_elec_0)
+-0.94999999999999996 w(bus_test_postheat_elec_0)
 = 0
 
-c_e__class__oemof_core_network_entities_components_transformers_PostHeating___postheat(postheat_elec_1)_:
--1 w(bus_test_postheat_elec_1)
+c_e__class__oemof_core_network_entities_components_transformers_TwoInputsOneOutput___two_inputs_relation(postheat_elec_1)_:
+-0.94999999999999996 w(bus_test_postheat_elec_1)
 = 0
 
-c_e__class__oemof_core_network_entities_components_transformers_PostHeating___postheat(postheat_elec_2)_:
--1 w(bus_test_postheat_elec_2)
+c_e__class__oemof_core_network_entities_components_transformers_TwoInputsOneOutput___two_inputs_relation(postheat_elec_2)_:
+-0.94999999999999996 w(bus_test_postheat_elec_2)
 = 0
 
 c_e__class__oemof_core_network_entities_buses_HeatBus___balance(bus_distr_heat_0)_:

--- a/tests/lp_files/two_inputs_one_output_invest.lp
+++ b/tests/lp_files/two_inputs_one_output_invest.lp
@@ -2,55 +2,55 @@
 
 min 
 objective:
-+8024.1784764819377 _class__oemof_core_network_entities_components_transformers_PostHeating___add_out(postheat_elec)
++8024.1784764819377 _class__oemof_core_network_entities_components_transformers_TwoInputsOneOutput___add_out(postheat_elec)
 
 s.t.
 
-c_e__class__oemof_core_network_entities_components_transformers_PostHeating___io_relation(postheat_elec_0)_:
+c_e__class__oemof_core_network_entities_components_transformers_TwoInputsOneOutput___io_relation(postheat_elec_0)_:
 +1 w(bus_stor_heat_postheat_elec_0)
 +0.94999999999999996 w(bus_test_postheat_elec_0)
 -1 w(postheat_elec_bus_distr_heat_0)
 = 0
 
-c_e__class__oemof_core_network_entities_components_transformers_PostHeating___io_relation(postheat_elec_1)_:
+c_e__class__oemof_core_network_entities_components_transformers_TwoInputsOneOutput___io_relation(postheat_elec_1)_:
 +1 w(bus_stor_heat_postheat_elec_1)
 +0.94999999999999996 w(bus_test_postheat_elec_1)
 -1 w(postheat_elec_bus_distr_heat_1)
 = 0
 
-c_e__class__oemof_core_network_entities_components_transformers_PostHeating___io_relation(postheat_elec_2)_:
+c_e__class__oemof_core_network_entities_components_transformers_TwoInputsOneOutput___io_relation(postheat_elec_2)_:
 +1 w(bus_stor_heat_postheat_elec_2)
 +0.94999999999999996 w(bus_test_postheat_elec_2)
 -1 w(postheat_elec_bus_distr_heat_2)
 = 0
 
-c_u__class__oemof_core_network_entities_components_transformers_PostHeating___output_bound(postheat_elec_0)_:
--1 _class__oemof_core_network_entities_components_transformers_PostHeating___add_out(postheat_elec)
+c_e__class__oemof_core_network_entities_components_transformers_TwoInputsOneOutput___two_inputs_relation(postheat_elec_0)_:
++0.33333333333333331 w(bus_stor_heat_postheat_elec_0)
+-0.94999999999999996 w(bus_test_postheat_elec_0)
+= 0
+
+c_e__class__oemof_core_network_entities_components_transformers_TwoInputsOneOutput___two_inputs_relation(postheat_elec_1)_:
+-0.94999999999999996 w(bus_test_postheat_elec_1)
+= 0
+
+c_e__class__oemof_core_network_entities_components_transformers_TwoInputsOneOutput___two_inputs_relation(postheat_elec_2)_:
+-0.94999999999999996 w(bus_test_postheat_elec_2)
+= 0
+
+c_u__class__oemof_core_network_entities_components_transformers_TwoInputsOneOutput___output_bound(postheat_elec_0)_:
+-1 _class__oemof_core_network_entities_components_transformers_TwoInputsOneOutput___add_out(postheat_elec)
 +1 w(postheat_elec_bus_distr_heat_0)
 <= 999993
 
-c_u__class__oemof_core_network_entities_components_transformers_PostHeating___output_bound(postheat_elec_1)_:
--1 _class__oemof_core_network_entities_components_transformers_PostHeating___add_out(postheat_elec)
+c_u__class__oemof_core_network_entities_components_transformers_TwoInputsOneOutput___output_bound(postheat_elec_1)_:
+-1 _class__oemof_core_network_entities_components_transformers_TwoInputsOneOutput___add_out(postheat_elec)
 +1 w(postheat_elec_bus_distr_heat_1)
 <= 999993
 
-c_u__class__oemof_core_network_entities_components_transformers_PostHeating___output_bound(postheat_elec_2)_:
--1 _class__oemof_core_network_entities_components_transformers_PostHeating___add_out(postheat_elec)
+c_u__class__oemof_core_network_entities_components_transformers_TwoInputsOneOutput___output_bound(postheat_elec_2)_:
+-1 _class__oemof_core_network_entities_components_transformers_TwoInputsOneOutput___add_out(postheat_elec)
 +1 w(postheat_elec_bus_distr_heat_2)
 <= 999993
-
-c_e__class__oemof_core_network_entities_components_transformers_PostHeating___postheat(postheat_elec_0)_:
-+0.33333333333333331 w(bus_stor_heat_postheat_elec_0)
--1 w(bus_test_postheat_elec_0)
-= 0
-
-c_e__class__oemof_core_network_entities_components_transformers_PostHeating___postheat(postheat_elec_1)_:
--1 w(bus_test_postheat_elec_1)
-= 0
-
-c_e__class__oemof_core_network_entities_components_transformers_PostHeating___postheat(postheat_elec_2)_:
--1 w(bus_test_postheat_elec_2)
-= 0
 
 c_e__class__oemof_core_network_entities_buses_HeatBus___balance(bus_distr_heat_0)_:
 +1 w(postheat_elec_bus_distr_heat_0)
@@ -101,5 +101,5 @@ bounds
    0 <= w(postheat_elec_bus_distr_heat_0) <= +inf
    0 <= w(postheat_elec_bus_distr_heat_1) <= +inf
    0 <= w(postheat_elec_bus_distr_heat_2) <= +inf
-   0 <= _class__oemof_core_network_entities_components_transformers_PostHeating___add_out(postheat_elec) <= +inf
+   0 <= _class__oemof_core_network_entities_components_transformers_TwoInputsOneOutput___add_out(postheat_elec) <= +inf
 end 


### PR DESCRIPTION
The PostHeating class was created to describe a instantaneous flow heater. The new idea is describe a more generic class that describes a general transformer that has two inputs and one output.
This transformer can represent a heat pump, an instant flow heater or any other component with two inputs and one output.

See issue #114 for more information