### PR TITLE
'Investment' blocks in add_opex_fix

### DIFF
--- a/oemof/solph/objective_expressions.py
+++ b/oemof/solph/objective_expressions.py
@@ -106,7 +106,7 @@ def add_opex_fix(model, block, ref=None):
         if block.uids is None:
             block.uids = [obj.uid for obj in block.objs]
         uids_inv = set([obj.uid for obj in block.objs
-                       if block.optimization_options.get('investment', False)])
+                       if block.optimization_options.get('investment', True)])
         uids = set(block.uids) - uids_inv
 
         opex_fix = {obj.uid: obj.opex_fix for obj in block.objs}


### PR DESCRIPTION
I think 'False' should be changed to 'True' to obtain the set of investment blocks. Otherwise, the code doesn't match the [documentation](http://pythonhosted.org/oemof_base/api/oemof.solph.html#oemof.solph.objective_expressions.add_opex_fix).