### PR TITLE
Features/change plot order

### DIFF
--- a/doc/whatsnew/v0-0-6.rst
+++ b/doc/whatsnew/v0-0-6.rst
@@ -7,6 +7,7 @@ New features
   with the BDEW  heat load profile method should only include space heating
   or space heating and warm water combined.
   (`Issue #130 <https://github.com/oemof/oemof/issues/130>`_)
+* Add possibility to change the order of the columns of a DataFrame subset. This is useful to change the order of stacked plots. (`Issue #148 <https://github.com/oemof/oemof/issues/148>`_)
 
 Documentation
 #############

--- a/examples/storage_optimization/storage_invest.py
+++ b/examples/storage_optimization/storage_invest.py
@@ -196,7 +196,10 @@ plt.rcParams.update({'font.size': 19})
 plt.style.use('grayscale')
 
 handles, labels = myplot.io_plot(
-    bus_uid="bel", cdict=cdict, line_kwa={'linewidth': 4},
+    bus_uid="bel", cdict=cdict,
+    barorder=['pv', 'wind', 'pp_gas', 'sto_simple'],
+    lineorder=['demand', 'sto_simple'],
+    line_kwa={'linewidth': 4},
     ax=fig.add_subplot(1, 1, 1),
     date_from="2012-06-01 00:00:00",
     date_to="2012-06-8 00:00:00",

--- a/oemof/outputlib/to_pandas.py
+++ b/oemof/outputlib/to_pandas.py
@@ -216,6 +216,29 @@ class DataFramePlot(ResultsDataFrame):
                 unstacklevel='obj_uid', **kwargs)
         return self
 
+    def rearrange_subset(self, order):
+        r"""
+        Change the order of the subset DataFrame
+
+        Parameters
+        ----------
+        order : list
+            New order of columns
+
+        Returns
+        -------
+        self
+        """
+        cols = list(self.subset.columns.values)
+        neworder = [x for x in list(order) if x in set(cols)]
+        missing = [x for x in list(cols) if x not in set(order)]
+        if len(missing) > 0:
+            logging.warning(
+                "Columns that are not part of the order list are removed: " +
+                str(missing))
+        print(neworder)
+        self.subset = self.subset[neworder]
+
     def color_from_dict(self, colordict):
         r""" Method to convert a dictionary containing the components and its
         colors to a color list that can be directly useed with the color


### PR DESCRIPTION
I added a method to change the order of the columns within a DataFrame subset. So people will be able to change the order and use the pandas plotting method afterwards. This is useful for stacked plots.

```python
>>> myplot = DataFramePlot()
>>> myplot.subset.columns.values
['a', 'b', 'c', 'd']
>>> myplot.rearrange_subset(['b', 'd', 'a', 'c'])
>>> myplot.subset.columns.values
['b', 'd', 'a', 'c']
>>> myplot.plot(stacked=True)
```