### PR TITLE
Fix issue 190

### DIFF
--- a/examples/example_tests.py
+++ b/examples/example_tests.py
@@ -123,22 +123,22 @@ except Exception as e:
 
 test_results = {
     'objective': 2947725.249402091,
-    ('b_el', 'tobus', 'pp_chp', 'val'): 11161.357450000065,
-    ('b_el', 'tobus', 'pp_coal', 'val'): 33723.047672110595,
-    ('b_el', 'tobus', 'pp_gas', 'val'): 30412.377779000046,
-    ('b_el', 'tobus', 'pp_lig', 'val'): 22066.451080999268,
-    ('b_el', 'tobus', 'pp_oil', 'val'): 2.2872599999999998,
-    ('b_el', 'tobus', 'pv', 'val'): 7796.8431880300122,
-    ('b_el', 'tobus', 'wind', 'val'): 28009.549502999955,
-    ('b_el', 'frombus', 'demand_el', 'val'): 132243.7904593189,
-    ('b_el', 'frombus', 'excess', 'val'): 928.12139200000013,
-    ('b_th', 'tobus', 'pp_chp', 'val'): 14881.810039999958,
-    ('b_th', 'frombus', 'demand_th', 'val'): 14881.80983624002,
-    ('coal', 'frombus', 'pp_coal', 'val'): 86469.394787298472,
-    ('gas', 'frombus', 'pp_chp', 'val'): 37204.525720000034,
-    ('gas', 'frombus', 'pp_gas', 'val'): 60824.751778000136,
-    ('lignite', 'frombus', 'pp_lig', 'val'): 53820.634704001102,
-    ('oil', 'frombus', 'pp_oil', 'val'): 8.1687949999999994}
+    ('b_el', 'to_bus', 'pp_chp', 'val'): 11161.357450000065,
+    ('b_el', 'to_bus', 'pp_coal', 'val'): 33723.047672110595,
+    ('b_el', 'to_bus', 'pp_gas', 'val'): 30412.377779000046,
+    ('b_el', 'to_bus', 'pp_lig', 'val'): 22066.451080999268,
+    ('b_el', 'to_bus', 'pp_oil', 'val'): 2.2872599999999998,
+    ('b_el', 'to_bus', 'pv', 'val'): 7796.8431880300122,
+    ('b_el', 'to_bus', 'wind', 'val'): 28009.549502999955,
+    ('b_el', 'from_bus', 'demand_el', 'val'): 132243.7904593189,
+    ('b_el', 'from_bus', 'excess', 'val'): 928.12139200000013,
+    ('b_th', 'to_bus', 'pp_chp', 'val'): 14881.810039999958,
+    ('b_th', 'from_bus', 'demand_th', 'val'): 14881.80983624002,
+    ('coal', 'from_bus', 'pp_coal', 'val'): 86469.394787298472,
+    ('gas', 'from_bus', 'pp_chp', 'val'): 37204.525720000034,
+    ('gas', 'from_bus', 'pp_gas', 'val'): 60824.751778000136,
+    ('lignite', 'from_bus', 'pp_lig', 'val'): 53820.634704001102,
+    ('oil', 'from_bus', 'pp_oil', 'val'): 8.1687949999999994}
 
 check(test_results, least_costs_run, testdict['least_costs'], results)
 # *********** end of simple least cost  example *******************************

--- a/examples/example_tests.py
+++ b/examples/example_tests.py
@@ -123,22 +123,22 @@ except Exception as e:
 
 test_results = {
     'objective': 2947725.249402091,
-    ('b_el', 'input', 'pp_chp', 'val'): 11161.357450000065,
-    ('b_el', 'input', 'pp_coal', 'val'): 33723.047672110595,
-    ('b_el', 'input', 'pp_gas', 'val'): 30412.377779000046,
-    ('b_el', 'input', 'pp_lig', 'val'): 22066.451080999268,
-    ('b_el', 'input', 'pp_oil', 'val'): 2.2872599999999998,
-    ('b_el', 'input', 'pv', 'val'): 7796.8431880300122,
-    ('b_el', 'input', 'wind', 'val'): 28009.549502999955,
-    ('b_el', 'output', 'demand_el', 'val'): 132243.7904593189,
-    ('b_el', 'output', 'excess', 'val'): 928.12139200000013,
-    ('b_th', 'input', 'pp_chp', 'val'): 14881.810039999958,
-    ('b_th', 'output', 'demand_th', 'val'): 14881.80983624002,
-    ('coal', 'output', 'pp_coal', 'val'): 86469.394787298472,
-    ('gas', 'output', 'pp_chp', 'val'): 37204.525720000034,
-    ('gas', 'output', 'pp_gas', 'val'): 60824.751778000136,
-    ('lignite', 'output', 'pp_lig', 'val'): 53820.634704001102,
-    ('oil', 'output', 'pp_oil', 'val'): 8.1687949999999994}
+    ('b_el', 'tobus', 'pp_chp', 'val'): 11161.357450000065,
+    ('b_el', 'tobus', 'pp_coal', 'val'): 33723.047672110595,
+    ('b_el', 'tobus', 'pp_gas', 'val'): 30412.377779000046,
+    ('b_el', 'tobus', 'pp_lig', 'val'): 22066.451080999268,
+    ('b_el', 'tobus', 'pp_oil', 'val'): 2.2872599999999998,
+    ('b_el', 'tobus', 'pv', 'val'): 7796.8431880300122,
+    ('b_el', 'tobus', 'wind', 'val'): 28009.549502999955,
+    ('b_el', 'frombus', 'demand_el', 'val'): 132243.7904593189,
+    ('b_el', 'frombus', 'excess', 'val'): 928.12139200000013,
+    ('b_th', 'tobus', 'pp_chp', 'val'): 14881.810039999958,
+    ('b_th', 'frombus', 'demand_th', 'val'): 14881.80983624002,
+    ('coal', 'frombus', 'pp_coal', 'val'): 86469.394787298472,
+    ('gas', 'frombus', 'pp_chp', 'val'): 37204.525720000034,
+    ('gas', 'frombus', 'pp_gas', 'val'): 60824.751778000136,
+    ('lignite', 'frombus', 'pp_lig', 'val'): 53820.634704001102,
+    ('oil', 'frombus', 'pp_oil', 'val'): 8.1687949999999994}
 
 check(test_results, least_costs_run, testdict['least_costs'], results)
 # *********** end of simple least cost  example *******************************

--- a/examples/solph/simple_least_costs/simple_least_costs.py
+++ b/examples/solph/simple_least_costs/simple_least_costs.py
@@ -132,7 +132,7 @@ def plot_results(energysystem):
     # create multiindex dataframe with result values
     esplot = output.DataFramePlot(energy_system=energysystem)
     # select input results of electrical bus (i.e. power delivered by plants)
-    esplot.slice_unstacked(bus_label="b_el", type="input",
+    esplot.slice_unstacked(bus_label="b_el", type="tobus",
                            date_from='2012-01-01 00:00:00',
                            date_to='2012-01-07 00:00:00')
     # set colorlist for esplot

--- a/examples/solph/simple_least_costs/simple_least_costs.py
+++ b/examples/solph/simple_least_costs/simple_least_costs.py
@@ -132,7 +132,7 @@ def plot_results(energysystem):
     # create multiindex dataframe with result values
     esplot = output.DataFramePlot(energy_system=energysystem)
     # select input results of electrical bus (i.e. power delivered by plants)
-    esplot.slice_unstacked(bus_label="b_el", type="tobus",
+    esplot.slice_unstacked(bus_label="b_el", type="to_bus",
                            date_from='2012-01-01 00:00:00',
                            date_to='2012-01-07 00:00:00')
     # set colorlist for esplot

--- a/examples/solph/storage_optimization/storage_invest.py
+++ b/examples/solph/storage_optimization/storage_invest.py
@@ -141,7 +141,7 @@ def get_result_dict(energysystem):
     storage = energysystem.groups['storage']
     myresults = outputlib.DataFramePlot(energy_system=energysystem)
 
-    pp_gas = myresults.slice_by(obj_label='pp_gas', type='input',
+    pp_gas = myresults.slice_by(obj_label='pp_gas', type='tobus',
                                 date_from='2012-01-01 00:00:00',
                                 date_to='2012-12-31 23:00:00')
 
@@ -182,7 +182,7 @@ def create_plots(energysystem):
 
     # Plotting the input flows of the electricity bus for January
     myplot = outputlib.DataFramePlot(energy_system=energysystem)
-    myplot.slice_unstacked(bus_label="electricity", type="input",
+    myplot.slice_unstacked(bus_label="electricity", type="tobus",
                            date_from="2012-01-01 00:00:00",
                            date_to="2012-01-31 00:00:00")
     colorlist = myplot.color_from_dict(cdict)
@@ -193,7 +193,7 @@ def create_plots(energysystem):
     myplot.set_datetime_ticks(date_format='%d-%m-%Y', tick_distance=24*7)
 
     # Plotting the output flows of the electricity bus for January
-    myplot.slice_unstacked(bus_label="electricity", type="output")
+    myplot.slice_unstacked(bus_label="electricity", type="frombus")
     myplot.plot(title="Year 2016", colormap='Spectral', linewidth=2)
     myplot.ax.legend(loc='upper right')
     myplot.ax.set_ylabel('Power in MW')

--- a/examples/solph/storage_optimization/storage_invest.py
+++ b/examples/solph/storage_optimization/storage_invest.py
@@ -141,7 +141,7 @@ def get_result_dict(energysystem):
     storage = energysystem.groups['storage']
     myresults = outputlib.DataFramePlot(energy_system=energysystem)
 
-    pp_gas = myresults.slice_by(obj_label='pp_gas', type='tobus',
+    pp_gas = myresults.slice_by(obj_label='pp_gas', type='to_bus',
                                 date_from='2012-01-01 00:00:00',
                                 date_to='2012-12-31 23:00:00')
 
@@ -182,7 +182,7 @@ def create_plots(energysystem):
 
     # Plotting the input flows of the electricity bus for January
     myplot = outputlib.DataFramePlot(energy_system=energysystem)
-    myplot.slice_unstacked(bus_label="electricity", type="tobus",
+    myplot.slice_unstacked(bus_label="electricity", type="to_bus",
                            date_from="2012-01-01 00:00:00",
                            date_to="2012-01-31 00:00:00")
     colorlist = myplot.color_from_dict(cdict)
@@ -193,7 +193,7 @@ def create_plots(energysystem):
     myplot.set_datetime_ticks(date_format='%d-%m-%Y', tick_distance=24*7)
 
     # Plotting the output flows of the electricity bus for January
-    myplot.slice_unstacked(bus_label="electricity", type="frombus")
+    myplot.slice_unstacked(bus_label="electricity", type="from_bus")
     myplot.plot(title="Year 2016", colormap='Spectral', linewidth=2)
     myplot.ax.legend(loc='upper right')
     myplot.ax.set_ylabel('Power in MW')

--- a/oemof/outputlib/__init__.py
+++ b/oemof/outputlib/__init__.py
@@ -68,7 +68,7 @@ class ResultsDataFrame(pd.DataFrame):
                     if k is kk:
                         row['type'] = 'other'
                     else:
-                        row['type'] = 'output'
+                        row['type'] = 'frombus'
                     if k is kk:
                         row['obj_label'] = 'duals'
                     elif isinstance(kk, str):
@@ -95,7 +95,7 @@ class ResultsDataFrame(pd.DataFrame):
                             # bus inputs (only self ref. components)
                             row = {}
                             row['bus_label'] = list(k.outputs.keys())[0].label
-                            row['type'] = 'input'
+                            row['type'] = 'tobus'
                             row['obj_label'] = k.label
                             row['datetime'] = es.time_idx
                             row['val'] = v.get(list(k.outputs.keys())[0])
@@ -105,7 +105,7 @@ class ResultsDataFrame(pd.DataFrame):
                         # bus inputs (results[component][bus])
                         row = {}
                         row['bus_label'] = kk.label
-                        row['type'] = 'input'
+                        row['type'] = 'tobus'
                         row['obj_label'] = k.label
                         row['datetime'] = es.time_idx
                         row['val'] = vv
@@ -133,7 +133,7 @@ class ResultsDataFrame(pd.DataFrame):
         Parameters
         ----------
         bus_label : string
-        type : string (input/output/other)
+        type : string (tobus/frombus/other)
         obj_label: string
         date_from : string
             Start date selection e.g. "2016-01-01 00:00:00". If not set, the
@@ -403,7 +403,7 @@ class DataFramePlot(ResultsDataFrame):
             self.ax = fig.add_subplot(1, 1, 1)
 
         # Create a bar plot for all input flows
-        self.slice_unstacked(bus_label=bus_label, type='input', **kwargs)
+        self.slice_unstacked(bus_label=bus_label, type='tobus', **kwargs)
         if barorder is not None:
             self.rearrange_subset(barorder)
         self.subset.plot(kind='bar', linewidth=0, stacked=True, width=1,
@@ -411,7 +411,7 @@ class DataFramePlot(ResultsDataFrame):
                          **bar_kwa)
 
         # Create a line plot for all output flows
-        self.slice_unstacked(bus_label=bus_label, type='output', **kwargs)
+        self.slice_unstacked(bus_label=bus_label, type='frombus', **kwargs)
         if lineorder is not None:
             self.rearrange_subset(lineorder)
         # The following changes are made to have the bottom line on top layer

--- a/oemof/outputlib/__init__.py
+++ b/oemof/outputlib/__init__.py
@@ -5,7 +5,7 @@ import logging
 import pandas as pd
 try:
     import matplotlib.pyplot as plt
-except:
+except ImportError:
     logging.warning('Matplotlib does not work.')
 
 
@@ -41,29 +41,15 @@ class ResultsDataFrame(pd.DataFrame):
         http://pandas.pydata.org/pandas-docs/stable/advanced.html
 
     """
-
-
-#         results[source][target]
-#         if source == target:
-#           if isinstance(source, 'Bus'):
-#               if isinstance(target.key(), str):
-#                   # duals
-#                   pass
-#               else:
-#                   storage_level
-#         else:
-#             # component logic
-#             pass
-
     def __init__(self, **kwargs):
         # default values if not arguments are passed
         es = kwargs.get('energy_system')
 
         rows_list = []
         for k, v in es.results.items():
-            if ('Bus' in str(k.__class__)):
+            if 'Bus' in str(k.__class__):
                 for kk, vv in v.items():
-                    row = {}
+                    row = dict()
                     row['bus_label'] = k.label
                     if k is kk:
                         row['type'] = 'other'
@@ -82,9 +68,9 @@ class ResultsDataFrame(pd.DataFrame):
                 if k in v.keys():
                     # self ref. components (results[component][component])
                     for kk, vv in v.items():
-                        if(k is kk):
+                        if k is kk:
                             # self ref. comp. (results[component][component])
-                            row = {}
+                            row = dict()
                             row['bus_label'] = list(k.outputs.keys())[0].label
                             row['type'] = 'other'
                             row['obj_label'] = k.label
@@ -93,7 +79,7 @@ class ResultsDataFrame(pd.DataFrame):
                             rows_list.append(row)
                         else:
                             # bus inputs (only self ref. components)
-                            row = {}
+                            row = dict()
                             row['bus_label'] = list(k.outputs.keys())[0].label
                             row['type'] = 'tobus'
                             row['obj_label'] = k.label
@@ -103,7 +89,7 @@ class ResultsDataFrame(pd.DataFrame):
                 else:
                     for kk, vv in v.items():
                         # bus inputs (results[component][bus])
-                        row = {}
+                        row = dict()
                         row['bus_label'] = kk.label
                         row['type'] = 'tobus'
                         row['obj_label'] = k.label
@@ -172,6 +158,8 @@ class ResultsDataFrame(pd.DataFrame):
         ----------
         unstacklevel : string (default: 'obj_label')
             Level to unstack the subset of the DataFrame.
+        formatted : boolean
+            missing...
         """
         subset = self.slice_by(**kwargs)
         subset = subset.unstack(level=unstacklevel)
@@ -364,8 +352,8 @@ class DataFramePlot(ResultsDataFrame):
         self.ax = self.subset.plot(**kwargs)
         return self
 
-    def io_plot(self, bus_label, cdict, line_kwa={}, lineorder=None, bar_kwa={},
-                barorder=None, **kwargs):
+    def io_plot(self, bus_label, cdict, line_kwa=None, lineorder=None,
+                bar_kwa=None, barorder=None, **kwargs):
         r""" Plotting a combined bar and line plot to see the fitting of in-
         and outcomming flows of a bus balance.
 
@@ -397,6 +385,11 @@ class DataFramePlot(ResultsDataFrame):
             stack line plot. You can use them for further maipulations.
         """
         self.ax = kwargs.get('ax', self.ax)
+
+        if bar_kwa is None:
+            bar_kwa = dict()
+        if line_kwa is None:
+            line_kwa = dict()
 
         if self.ax is None:
             fig = plt.figure()

--- a/oemof/outputlib/__init__.py
+++ b/oemof/outputlib/__init__.py
@@ -54,7 +54,7 @@ class ResultsDataFrame(pd.DataFrame):
                     if k is kk:
                         row['type'] = 'other'
                     else:
-                        row['type'] = 'frombus'
+                        row['type'] = 'from_bus'
                     if k is kk:
                         row['obj_label'] = 'duals'
                     elif isinstance(kk, str):
@@ -81,7 +81,7 @@ class ResultsDataFrame(pd.DataFrame):
                             # bus inputs (only self ref. components)
                             row = dict()
                             row['bus_label'] = list(k.outputs.keys())[0].label
-                            row['type'] = 'tobus'
+                            row['type'] = 'to_bus'
                             row['obj_label'] = k.label
                             row['datetime'] = es.time_idx
                             row['val'] = v.get(list(k.outputs.keys())[0])
@@ -91,7 +91,7 @@ class ResultsDataFrame(pd.DataFrame):
                         # bus inputs (results[component][bus])
                         row = dict()
                         row['bus_label'] = kk.label
-                        row['type'] = 'tobus'
+                        row['type'] = 'to_bus'
                         row['obj_label'] = k.label
                         row['datetime'] = es.time_idx
                         row['val'] = vv
@@ -119,7 +119,7 @@ class ResultsDataFrame(pd.DataFrame):
         Parameters
         ----------
         bus_label : string
-        type : string (tobus/frombus/other)
+        type : string (to_bus/from_bus/other)
         obj_label: string
         date_from : string
             Start date selection e.g. "2016-01-01 00:00:00". If not set, the
@@ -396,7 +396,7 @@ class DataFramePlot(ResultsDataFrame):
             self.ax = fig.add_subplot(1, 1, 1)
 
         # Create a bar plot for all input flows
-        self.slice_unstacked(bus_label=bus_label, type='tobus', **kwargs)
+        self.slice_unstacked(bus_label=bus_label, type='to_bus', **kwargs)
         if barorder is not None:
             self.rearrange_subset(barorder)
         self.subset.plot(kind='bar', linewidth=0, stacked=True, width=1,
@@ -404,7 +404,7 @@ class DataFramePlot(ResultsDataFrame):
                          **bar_kwa)
 
         # Create a line plot for all output flows
-        self.slice_unstacked(bus_label=bus_label, type='frombus', **kwargs)
+        self.slice_unstacked(bus_label=bus_label, type='from_bus', **kwargs)
         if lineorder is not None:
             self.rearrange_subset(lineorder)
         # The following changes are made to have the bottom line on top layer


### PR DESCRIPTION
The name of the keyword is not important to me so change it if you want.

I renamed the keyword of the results DataFrame from `input` to `tobus` and from `output` to `frombus` to make it a bit more intuitive. See #190 for more details.

**Before:**

```python
input_into_pp_gas = myresults.slice_by(obj_label='pp_gas', type='output')
output_from_pp_gas = myresults.slice_by(obj_label='pp_gas', type='input')
```

**Now:**

```python
input_into_pp_gas = myresults.slice_by(obj_label='pp_gas', type='frombus')
output_from_pp_gas = myresults.slice_by(obj_label='pp_gas', type='tobus')
```