### PR TITLE
Clearfiy API oemof core: EnergySystem attribute time_idx -> time_index

### DIFF
--- a/examples/solph/csv_reader/investment_example.py
+++ b/examples/solph/csv_reader/investment_example.py
@@ -26,7 +26,7 @@ date_to = '2050-01-01 23:00:00'
 
 datetime_index = pd.date_range(date_from, date_to, freq='60min')
 
-es = EnergySystem(groupings=GROUPINGS, time_idx=datetime_index)
+es = EnergySystem(groupings=GROUPINGS, timeindex=datetime_index)
 
 nodes = NodesFromCSV(file_nodes_flows='data/nodes_flows.csv',
                      file_nodes_flows_sequences='data/nodes_flows_seq.csv',

--- a/examples/solph/flexible_modelling/add_constraints.py
+++ b/examples/solph/flexible_modelling/add_constraints.py
@@ -16,7 +16,7 @@ from oemof.solph import (Sink, LinearTransformer, Bus, Flow,
 ####### creating an oemof solph optimization model, nothing special here ######
 # create an energy system object for the oemof solph nodes
 es = EnergySystem(groupings=GROUPINGS,
-                  time_idx=pd.date_range('1/1/2012', periods=4, freq='H'))
+                  timeindex=pd.date_range('1/1/2012', periods=4, freq='H'))
 # add some nodes
 boil = Bus(label="oil", balanced=False)
 blig = Bus(label="lignite", balanced=False)

--- a/examples/solph/simple_least_costs/simple_least_costs.py
+++ b/examples/solph/simple_least_costs/simple_least_costs.py
@@ -27,7 +27,7 @@ def initialise_energysystem(periods=2000):
     """
     datetimeindex = pd.date_range('1/1/2012', periods=periods, freq='H')
 
-    return EnergySystem(groupings=GROUPINGS, time_idx=datetimeindex)
+    return EnergySystem(groupings=GROUPINGS, timeindex=datetimeindex)
 
 
 # ######################### create energysystem components ####################

--- a/examples/solph/storage_optimization/storage_invest.py
+++ b/examples/solph/storage_optimization/storage_invest.py
@@ -53,7 +53,7 @@ def optimise_storage_size(filename="storage_invest.csv", solvername='cbc',
                                     freq='H')
 
     energysystem = solph.EnergySystem(
-        groupings=solph.GROUPINGS, time_idx=date_time_index)
+        groupings=solph.GROUPINGS, timeindex=date_time_index)
 
     # Read data file
     data = pd.read_csv(filename, sep=",")

--- a/oemof/energy_system.py
+++ b/oemof/energy_system.py
@@ -39,7 +39,7 @@ class EnergySystem:
         <oemof.core.network.Entity>` that should be part of the energy system.
         Stored in the :attr:`entities` attribute.
         Defaults to `[]` if not supplied.
-    time_idx : pandas.index, optional
+    timeindex : pandas.index, optional
         Define the time range and increment for the energy system. This is an
         optional parameter but might be import for other functions/methods that
         use the EnergySystem class as an input parameter.
@@ -73,7 +73,7 @@ class EnergySystem:
         <oemof.solph.optimization_model.OptimizationModel.results>`.
         See the documentation of that method for a detailed description of the
         structure of the results dictionary.
-    time_idx : pandas.index, optional
+    timeindex : pandas.index, optional
         Define the time range and increment for the energy system. This is an
         optional atribute but might be import for other functions/methods that
         use the EnergySystem class as an input parameter.
@@ -125,7 +125,7 @@ class EnergySystem:
             for g in self._groupings:
                 g(e, self.groups)
         self.results = kwargs.get('results')
-        self.time_idx = kwargs.get('time_idx')
+        self.timeindex = kwargs.get('timeindex')
 
     @staticmethod
     def _regroup(entity, groups, groupings):

--- a/oemof/outputlib/__init__.py
+++ b/oemof/outputlib/__init__.py
@@ -61,7 +61,7 @@ class ResultsDataFrame(pd.DataFrame):
                         row['obj_label'] = 'kk'
                     else:
                         row['obj_label'] = kk.label
-                    row['datetime'] = es.time_idx
+                    row['datetime'] = es.timeindex
                     row['val'] = vv
                     rows_list.append(row)
             else:
@@ -74,7 +74,7 @@ class ResultsDataFrame(pd.DataFrame):
                             row['bus_label'] = list(k.outputs.keys())[0].label
                             row['type'] = 'other'
                             row['obj_label'] = k.label
-                            row['datetime'] = es.time_idx
+                            row['datetime'] = es.timeindex
                             row['val'] = vv
                             rows_list.append(row)
                         else:
@@ -83,7 +83,7 @@ class ResultsDataFrame(pd.DataFrame):
                             row['bus_label'] = list(k.outputs.keys())[0].label
                             row['type'] = 'to_bus'
                             row['obj_label'] = k.label
-                            row['datetime'] = es.time_idx
+                            row['datetime'] = es.timeindex
                             row['val'] = v.get(list(k.outputs.keys())[0])
                             rows_list.append(row)
                 else:
@@ -93,7 +93,7 @@ class ResultsDataFrame(pd.DataFrame):
                         row['bus_label'] = kk.label
                         row['type'] = 'to_bus'
                         row['obj_label'] = k.label
-                        row['datetime'] = es.time_idx
+                        row['datetime'] = es.timeindex
                         row['val'] = vv
                         rows_list.append(row)
 

--- a/oemof/solph/models.py
+++ b/oemof/solph/models.py
@@ -110,7 +110,7 @@ class OperationalModel(po.ConcreteModel):
 
         self.name = kwargs.get('name', 'OperationalModel')
         self.es = es
-        self.timeindex = kwargs.get('timeindex', es.time_idx)
+        self.timeindex = kwargs.get('timeindex', es.timeindex)
         self.timesteps = kwargs.get('timesteps', range(len(self.timeindex)))
         self.timeincrement = kwargs.get('timeincrement',
                                         self.timeindex.freq.nanos / 3.6e12)

--- a/tests/basic_tests.py
+++ b/tests/basic_tests.py
@@ -20,7 +20,7 @@ class EnergySystem_Tests:
 
     @classmethod
     def setUpClass(self):
-        self.time_index = pd.date_range('1/1/2012', periods=5, freq='H')
+        self.timeindex = pd.date_range('1/1/2012', periods=5, freq='H')
 
         #timesteps=range(len(time_index)))
 
@@ -34,7 +34,7 @@ class EnergySystem_Tests:
         bus2 = Bus(label='bus-uid2', type='bus-type')
         Transformer(label='pp_gas', inputs=[bus], outputs=[bus2])
         ok_(isinstance(self.es.entities[2], Transformer))
-        self.es.timeindex = self.time_index
+        self.es.timeindex = self.timeindex
         ok_(len(self.es.timeindex) == 5)
 
     def test_entity_grouping_on_construction(self):

--- a/tests/basic_tests.py
+++ b/tests/basic_tests.py
@@ -34,8 +34,8 @@ class EnergySystem_Tests:
         bus2 = Bus(label='bus-uid2', type='bus-type')
         Transformer(label='pp_gas', inputs=[bus], outputs=[bus2])
         ok_(isinstance(self.es.entities[2], Transformer))
-        self.es.time_idx = self.time_index
-        ok_(len(self.es.time_idx) == 5)
+        self.es.timeindex = self.time_index
+        ok_(len(self.es.timeindex) == 5)
 
     def test_entity_grouping_on_construction(self):
         bus = Bus(label="test bus")

--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -32,11 +32,11 @@ class Constraint_Tests:
 
     def setup(self):
         self.energysystem = core_es.EnergySystem(groupings=solph.GROUPINGS,
-                                                 time_idx=self.date_time_index)
+                                                 timeindex=self.date_time_index)
 
     def compare_lp_files(self, filename, ignored=None):
         om = OperationalModel(self.energysystem,
-                              timeindex=self.energysystem.time_idx)
+                              timeindex=self.energysystem.timeindex)
         tmp_filename = filename.replace('.lp', '') + '_tmp.lp'
         new_filename = ospath.join(self.tmppath, tmp_filename)
         om.write(new_filename, io_options={'symbolic_solver_labels': True})

--- a/tests/regression_tests.py
+++ b/tests/regression_tests.py
@@ -16,7 +16,7 @@ class TestSolphAndItsResults:
         self.failed = False
 
         tix = pd.period_range('1970-01-01', periods=1, freq='H')
-        self.es = ES(time_idx=tix)
+        self.es = ES(timeindex=tix)
 
     # TODO: Fix this test so that it works with the new solph and can be
     #       re-enabled.


### PR DESCRIPTION
@simnh wrote:
> We should fix this at is kind of confusing because inside the examples and the OperationalModel class we use 'time_index' whereas inside EnergySystem class we use 'time_idx'...