### PR TITLE
Fix "get version number in logging"

### DIFF
--- a/oemof/tools/logger.py
+++ b/oemof/tools/logger.py
@@ -69,11 +69,8 @@ def define_logging(inifile='logging.ini', basicpath=None,
 
 def check_version():
     """Returns the actual version number of the used oemof version."""
-    filename = os.path.join(os.path.dirname(__file__), os.path.pardir,
-                            os.path.pardir, 'VERSION')
-    f = open(filename, 'r')
-    f.read(14)
-    version = f.read().replace('"', '')
+    import oemof
+    version = oemof.__version__
     logging.info("Used oemof version: {0}".format(version))
 
 

--- a/oemof/tools/logger.py
+++ b/oemof/tools/logger.py
@@ -8,7 +8,7 @@ from oemof.tools import helpers
 
 
 def define_logging(inifile='logging.ini', basicpath=None,
-                   subdir='log_files'):
+                   subdir='log_files', log_version=True):
     r"""Initialise the logger using the logging.conf file in the local path.
 
     Several sentences providing an extended description. Refer to
@@ -26,6 +26,9 @@ def define_logging(inifile='logging.ini', basicpath=None,
     subdir : string, optional (default: 'log_files')
         The name of the subfolder of the basicpath where the log-files are
         stored.
+    log_version : boolean
+        If True the actual version or commit is logged while initialising the
+        logger.
 
     Notes
     -----
@@ -61,10 +64,11 @@ def define_logging(inifile='logging.ini', basicpath=None,
     logger = logging.getLogger('simpleExample')
     logger.debug('*********************************************************')
     logging.info('Path for logging: %s' % logpath)
-    try:
-        check_git_branch()
-    except FileNotFoundError:
-        check_version()
+    if log_version:
+        try:
+            check_git_branch()
+        except FileNotFoundError:
+            check_version()
 
 
 def check_version():


### PR DESCRIPTION
- When installed via pip no VERSION file available in
  virtualenvs/oemof__release_v0.1/lib/python3.4/site-packages/oemof/
- Fix is maybe slow due to import of whole oemof package, but it's easy
  (:
