### PR TITLE
Features/solph speed up

### DIFF
--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -8,7 +8,7 @@ from pyomo.core import (Var, Set, Constraint, BuildAction, Expression,
 from pyomo.core.base.block import SimpleBlock
 from .plumbing import LConstraint, LExpression, linear_constraint
 import timeit
-fast_build = True
+
 
 class Storage(SimpleBlock):
     """ Storages (no investment)
@@ -818,7 +818,7 @@ class LinearTransformer(SimpleBlock):
         I = {n: n._input() for n in group}
         O = {n: [o for o in n.outputs.keys()] for n in group}
 
-        fast_build = False
+        fast_build = True
         start = timeit.default_timer()
         if not fast_build:
             self.relation = Constraint(group, noruleinit=True)
@@ -845,15 +845,16 @@ class LinearTransformer(SimpleBlock):
                         lhs = LExpression(variables=[(n.conversion_factors[o][t],
                                                       m.flow[I[n], n, t])])
                         rhs = LExpression(variables=[(1, m.flow[n, o, t])])
-                    input_output_relation[n, o, t] = LConstraint(lhs, '==', rhs)
+                        input_output_relation[(n, o, t)] = LConstraint(lhs, '==', rhs)
 
-            linear_constraint(self, 'relation_build',
+            linear_constraint(self, 'relation',
                               input_output_relation,
                               indices=[k for k in input_output_relation.keys()])
-
+            import pdb
+            pdb.set_trace()
         stop = timeit.default_timer()
-        #print('Time for relation constraint, fast {}: '.format(str(fast_build)),
-        #      stop - start)
+        print('Time for relation constraint, fast {}: '.format(str(fast_build)),
+              stop - start)
 
 
 class BinaryFlow(SimpleBlock):

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -818,7 +818,7 @@ class LinearTransformer(SimpleBlock):
         I = {n: n._input() for n in group}
         O = {n: [o for o in n.outputs.keys()] for n in group}
 
-        fast_build = True
+        fast_build = False
         start = timeit.default_timer()
         if not fast_build:
             self.relation = Constraint(group, noruleinit=True)
@@ -842,16 +842,15 @@ class LinearTransformer(SimpleBlock):
             for t in m.TIMESTEPS:
                 for n in group:
                     for o in O[n]:
-                        lhs = LExpression(variables=[(n.conversion_factors[o][t],
-                                                      m.flow[I[n], n, t])])
-                        rhs = LExpression(variables=[(1, m.flow[n, o, t])])
+                        lhs = LExpression(variables=[
+                            (n.conversion_factors[o][t], m.flow[I[n], n, t]),
+                            (-1, m.flow[n, o, t])])
+                        rhs = LExpression()
                         input_output_relation[(n, o, t)] = LConstraint(lhs, '==', rhs)
 
             linear_constraint(self, 'relation',
                               input_output_relation,
                               indices=[k for k in input_output_relation.keys()])
-            import pdb
-            pdb.set_trace()
         stop = timeit.default_timer()
         print('Time for relation constraint, fast {}: '.format(str(fast_build)),
               stop - start)

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -818,7 +818,7 @@ class LinearTransformer(SimpleBlock):
         I = {n: n._input() for n in group}
         O = {n: [o for o in n.outputs.keys()] for n in group}
 
-
+        fast_build = False
         start = timeit.default_timer()
         if not fast_build:
             self.relation = Constraint(group, noruleinit=True)
@@ -847,13 +847,13 @@ class LinearTransformer(SimpleBlock):
                         rhs = LExpression(variables=[(1, m.flow[n, o, t])])
                     input_output_relation[n, o, t] = LConstraint(lhs, '==', rhs)
 
-            linear_constraint(self, 'input_output_relation',
+            linear_constraint(self, 'relation_build',
                               input_output_relation,
                               indices=[k for k in input_output_relation.keys()])
 
         stop = timeit.default_timer()
-        print('Time for relation constraint, fast {}: '.format(str(fast_build)),
-              stop - start)
+        #print('Time for relation constraint, fast {}: '.format(str(fast_build)),
+        #      stop - start)
 
 
 class BinaryFlow(SimpleBlock):

--- a/oemof/solph/plumbing.py
+++ b/oemof/solph/plumbing.py
@@ -3,6 +3,8 @@
 
 """
 from collections import abc, UserList
+from pyomo.core import Constraint, Objective
+import pyomo.core.base as po_base
 
 
 def Sequence(sequence_or_scalar):
@@ -78,3 +80,248 @@ class _Sequence(UserList):
             self.data[key] = value
 
 
+
+class LExpression(object):
+    """Affine linear expression of optimisation variables.
+
+    Affine expression of the form:
+
+    constant + coeff1*var1 + coeff2*var2 + ....
+
+    Parameters
+    ----------
+    variables : list
+        List of tuples of coefficients and variables
+        e.g. [(coeff1,var1),(coeff2,var2),...]
+    constant : float
+
+    Note
+    ----
+    Code has been taken and adapted from pyPSA
+    (https://github.com/FRESNA/PyPSA), Copyright 2015-2016
+    Tom Brown (FIAS), Jonas Hoersch (FIAS), GNU GPL 3
+    """
+
+    def __init__(self, variables=None, constant=0.):
+
+        if variables is None:
+            self.variables = []
+        else:
+            self.variables = variables
+
+        self.constant = constant
+
+    def __repr__(self):
+        return "{} + {}".format(self.variables, self.constant)
+
+
+    def __mul__(self, constant):
+        try:
+            constant = float(constant)
+        except:
+            print("Can only multiply an LExpression with a float!")
+            return None
+        return LExpression([(constant * item[0], item[1])
+                                 for item in self.variables],
+                            constant * self.constant)
+
+    def __rmul__(self, constant):
+        return self.__mul__(constant)
+
+    def __add__(self, other):
+        if type(other) is LExpression:
+            return LExpression(self.variables + other.variables,
+                               self.constant + other.constant)
+        else:
+            try:
+                constant = float(other)
+            except:
+                print("Can only add an LExpression to another \
+                       LExpression or a constant!")
+                return None
+            return LExpression(self.variables[:], self.constant+constant)
+
+
+    def __radd__(self,other):
+        return self.__add__(other)
+
+    def __pos__(self):
+        return self
+
+    def __neg__(self):
+        return -1*self
+
+class LConstraint(object):
+    """Constraint of optimisation variables.
+
+    Linear constraint of the form:
+
+        lhs sense rhs
+
+    Parameters
+    ----------
+    lhs : LExpression
+        Left-hand-side expression constraint
+    sense : string
+        Sense of constraint, one of: '==', '<=', '>='. Default is '=='.
+    rhs : LExpression
+        Right-hand-side expression of constraint
+
+    Note
+    ------
+    Code has been taken and adapted from pyPSA
+    (https://github.com/FRESNA/PyPSA), Copyright 2015-2016
+    Tom Brown (FIAS), Jonas Hoersch (FIAS), GNU GPL 3
+    """
+
+    def __init__(self, lhs=None, sense="==", rhs=None):
+
+        if lhs is None:
+            self.lhs = LExpression()
+        else:
+            self.lhs = lhs
+
+        self.sense = sense
+
+        if rhs is None:
+            self.rhs = LExpression()
+        else:
+            self.rhs = rhs
+
+    def __repr__(self):
+        return "{} {} {}".format(self.lhs, self.sense, self.rhs)
+
+
+def linear_constraint(block, name, constraints, *args, **kwargs):
+    """A replacement for pyomo's Constraint class that quickly builds linear
+    constraints.
+
+    Instead of pyomo standard call:
+
+    model.name = Constraint(index1, index2, ..., rule=f)
+
+    call instead:
+
+    linear_constraint(model, name, constraints, index1, index2,...)
+
+    where constraints is a dictionary of constraints of the form:
+
+    constraints[i] = LConstraint object
+
+    Parameters
+    ----------
+    block : pyomo.environ.Block
+        A pyomo block to which the constraint is added
+    name : string
+        Name of constraint that is added to the block
+    constraints : dict
+        A dictionary of constraints (see format above)
+    *args :
+        Indices of the constraints
+    **kwargs : possible keys: 'indices'
+        Own indices, if 'indices' exist in kwargs do not pass index1, index2 etc.
+        They will be overwritten.
+
+    Note
+    ------
+    Code has been taken and adapted from pyPSA
+    (https://github.com/FRESNA/PyPSA), Copyright 2015-2016
+    Tom Brown (FIAS), Jonas Hoersch (FIAS), GNU GPL 3
+    """
+
+    # if 'keys' exist use this as constraint keys, otherwise construct
+    # passed index *args: e.g. idx1,idx2....
+    if kwargs.get('indices') is not None:
+        keys = kwargs.get('indices')
+        setattr(block, name,
+                po_base.constraint.IndexedConstraint(noruleinit=True))
+        v = getattr(block, name)
+        v._index = keys
+    else:
+        # first we create a constraint with nothin in it
+        setattr(block, name, Constraint(*args, noruleinit=True))
+        # v is our constraint object
+        v = getattr(block, name)
+
+
+    for i in v._index:
+        c = constraints[i]
+        if type(c) is LConstraint:
+            variables = c.lhs.variables + [(-item[0],item[1])
+                                           for item in c.rhs.variables]
+            sense = c.sense
+            constant = c.rhs.constant - c.lhs.constant
+        else:
+            raise ValueError(('Argument `constraint` must be of type \
+                               LConstraint!'))
+
+        v._data[i] = po_base.constraint._GeneralConstraintData(None, v)
+        v._data[i]._body = po_base.expr_coopr3._SumExpression()
+        v._data[i]._body._args = [item[1] for item in variables]
+        v._data[i]._body._coef = [item[0] for item in variables]
+        v._data[i]._body._const = 0.
+        if sense == "==":
+            v._data[i]._equality = True
+            v._data[i]._lower = po_base.numvalue.NumericConstant(constant)
+            v._data[i]._upper = po_base.numvalue.NumericConstant(constant)
+        elif sense == "<=":
+            v._data[i]._equality = False
+            v._data[i]._lower = None
+            v._data[i]._upper = po_base.numvalue.NumericConstant(constant)
+        elif sense == ">=":
+            v._data[i]._equality = False
+            v._data[i]._lower = po_base.numvalue.NumericConstant(constant)
+            v._data[i]._upper = None
+        elif sense == "><":
+            v._data[i]._equality = False
+            v._data[i]._lower = po_base.numvalue.NumericConstant(constant[0])
+            v._data[i]._upper = po_base.numvalue.NumericConstant(constant[1])
+        else:
+            raise KeyError(
+                '`Sense` must be one of "==","<=",">=","><"; got: {}'.format(
+                                                                        sense))
+
+def linear_objective(model, objective=None):
+    """
+    A replacement for pyomo's Objective that quickly builds linear
+    objectives.
+
+    Instead of
+
+    model.objective = Objective(expr=sum(vars[i]*coeffs[i] for i in index)
+                      + constant)
+
+    call instead
+
+    linear_objective(model, objective)
+
+    where objective is an LExpression.
+
+    Variables may be repeated with different coefficients, which pyomo
+    will sum up.
+
+
+    Parameters
+    ----------
+    model : pyomo.core.Block
+        The pyomo block / model to which the objective expression is added.
+    objective : LExpression
+        Linear expression of the objective function.
+
+     Note
+    ------
+    Code has been taken and adapted from pyPSA
+    (https://github.com/FRESNA/PyPSA), Copyright 2015-2016
+    Tom Brown (FIAS), Jonas Hoersch (FIAS), GNU GPL 3
+    """
+
+    if objective is None:
+        objective = LExpression()
+
+    #initialise with a dummy
+    model.objective = Objective(expr = 0.)
+
+    model.objective._expr = po_base.expr_coopr3._SumExpression()
+    model.objective._expr._args = [item[1] for item in objective.variables]
+    model.objective._expr._coef = [item[0] for item in objective.variables]
+    model.objective._expr._const = objective.constant


### PR DESCRIPTION
This pull request aims to use functionality that has been implemented by the pypsa developers to speed up constraint building etc. We had that for the old version already, I think we should try to use it now as well. For the bus balance for example it is faster, and I think significantly for large instances.  Took me some time to implement it for lineartransformer as well. There it does not speed thins up (it's even slower but maybe it's still not equivalent to the old expression). So from my point of view the procedure would look like this:
- taking major constraints (busbalance, lineartransformer etc) and compare results for a large test instance (maybe renpassis europe model) 
- where we identify enhancement we will use the improved code. 

Right now you can check it out in the blocks.py module (look at the LinearTransformer class there) 

The test fail at the moment, because the lp-files look differently (but this is just due to different signs inside equations.