### PR TITLE
Change structure of network classes

### DIFF
--- a/doc/whatsnew/v0-1-2.rst
+++ b/doc/whatsnew/v0-1-2.rst
@@ -35,6 +35,7 @@ Bug fixes
 Other changes
 #############
 
+* speed up constraint-building process by removing unnecessary method call
 
 
 

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -59,6 +59,9 @@ class Storage(SimpleBlock):
         if group is None:
             return None
 
+        I = {n: [i for i in n.inputs][0] for n in group}
+        O = {n: [o for o in n.outputs][0] for n in group}
+
         self.STORAGES = Set(initialize=[n for n in group])
 
         def _storage_capacity_bound_rule(block, n, t):
@@ -87,9 +90,9 @@ class Storage(SimpleBlock):
             expr += block.capacity[n, t]
             expr += - block.capacity[n, m.previous_timesteps[t]] * (
                 1 - n.capacity_loss[t])
-            expr += (- m.flow[n.input, n, t] *
+            expr += (- m.flow[I[n], n, t] *
                      n.inflow_conversion_factor[t]) * m.timeincrement[t]
-            expr += (m.flow[n, n.output, t] /
+            expr += (m.flow[n, O[n], t] /
                      n.outflow_conversion_factor[t]) * m.timeincrement[t]
             return expr == 0
         self.balance = Constraint(self.STORAGES, m.TIMESTEPS,
@@ -230,8 +233,8 @@ class InvestmentStorage(SimpleBlock):
                           bounds=_storage_investvar_bound_rule)
 
         # ######################### CONSTRAINTS ###############################
-        i = {n: n.input for n in group}
-        o = {n: n.output for n in group}
+        i = {n: [i for i in n.inputs][0] for n in group}
+        o = {n: [o for o in n.outputs][0] for n in group}
 
         def _storage_balance_rule(block, n, t):
             """Rule definition for the storage energy balance.
@@ -815,7 +818,7 @@ class LinearTransformer(SimpleBlock):
 
         m = self.parent_block()
 
-        I = {n: n.input for n in group}
+        I = {n: [i for i in n.inputs][0] for n in group}
         O = {n: [o for o in n.outputs.keys()] for n in group}
 
         self.relation = Constraint(group, noruleinit=True)

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -87,9 +87,9 @@ class Storage(SimpleBlock):
             expr += block.capacity[n, t]
             expr += - block.capacity[n, m.previous_timesteps[t]] * (
                 1 - n.capacity_loss[t])
-            expr += (- m.flow[n._input(), n, t] *
+            expr += (- m.flow[n.input(), n, t] *
                      n.inflow_conversion_factor[t]) * m.timeincrement[t]
-            expr += (m.flow[n, n._output(), t] /
+            expr += (m.flow[n, n.output(), t] /
                      n.outflow_conversion_factor[t]) * m.timeincrement[t]
             return expr == 0
         self.balance = Constraint(self.STORAGES, m.TIMESTEPS,
@@ -230,8 +230,8 @@ class InvestmentStorage(SimpleBlock):
                           bounds=_storage_investvar_bound_rule)
 
         # ######################### CONSTRAINTS ###############################
-        i = {n: n._input() for n in group}
-        o = {n: n._output() for n in group}
+        i = {n: n.input() for n in group}
+        o = {n: n.output() for n in group}
 
         def _storage_balance_rule(block, n, t):
             """Rule definition for the storage energy balance.
@@ -815,7 +815,7 @@ class LinearTransformer(SimpleBlock):
 
         m = self.parent_block()
 
-        I = {n: n._input() for n in group}
+        I = {n: n.input() for n in group}
         O = {n: [o for o in n.outputs.keys()] for n in group}
 
         self.relation = Constraint(group, noruleinit=True)

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -87,9 +87,9 @@ class Storage(SimpleBlock):
             expr += block.capacity[n, t]
             expr += - block.capacity[n, m.previous_timesteps[t]] * (
                 1 - n.capacity_loss[t])
-            expr += (- m.flow[n.input(), n, t] *
+            expr += (- m.flow[n.input, n, t] *
                      n.inflow_conversion_factor[t]) * m.timeincrement[t]
-            expr += (m.flow[n, n.output(), t] /
+            expr += (m.flow[n, n.output, t] /
                      n.outflow_conversion_factor[t]) * m.timeincrement[t]
             return expr == 0
         self.balance = Constraint(self.STORAGES, m.TIMESTEPS,
@@ -230,8 +230,8 @@ class InvestmentStorage(SimpleBlock):
                           bounds=_storage_investvar_bound_rule)
 
         # ######################### CONSTRAINTS ###############################
-        i = {n: n.input() for n in group}
-        o = {n: n.output() for n in group}
+        i = {n: n.input for n in group}
+        o = {n: n.output for n in group}
 
         def _storage_balance_rule(block, n, t):
             """Rule definition for the storage energy balance.
@@ -815,7 +815,7 @@ class LinearTransformer(SimpleBlock):
 
         m = self.parent_block()
 
-        I = {n: n.input() for n in group}
+        I = {n: n.input for n in group}
         O = {n: [o for o in n.outputs.keys()] for n in group}
 
         self.relation = Constraint(group, noruleinit=True)

--- a/oemof/solph/network.py
+++ b/oemof/solph/network.py
@@ -204,10 +204,7 @@ class LinearTransformer(on.Transformer):
             k: Sequence(v)
             for k, v in kwargs.get('conversion_factors', {}).items()}
 
-    def input(self):
-        """ Returns the first (and only) input of the storage object
-        """
-        return [i for i in self.inputs][0]
+        self.input = [i for i in self.inputs][0]
 
 
 class Storage(on.Transformer):
@@ -307,15 +304,8 @@ class Storage(on.Transformer):
                 if not isinstance(flow.investment, Investment):
                     flow.investment = Investment()
 
-    def input(self):
-        """ Returns the first (and only) input of the storage object
-        """
-        return [i for i in self.inputs][0]
-
-    def output(self):
-        """ Returns the first (and only) output of the storage object
-        """
-        return [o for o in self.outputs][0]
+        self.input = [i for i in self.inputs][0]
+        self.output = [o for o in self.outputs][0]
 
 
 def storage_nominal_value_warning(flow):

--- a/oemof/solph/network.py
+++ b/oemof/solph/network.py
@@ -207,7 +207,7 @@ class LinearTransformer(on.Transformer):
             k: Sequence(v)
             for k, v in kwargs.get('conversion_factors', {}).items()}
 
-        self.input = [i for i in self.inputs][0]
+        # self.input = [i for i in self.inputs][0]
 
 
 class Storage(on.Transformer):
@@ -307,8 +307,8 @@ class Storage(on.Transformer):
                 if not isinstance(flow.investment, Investment):
                     flow.investment = Investment()
 
-        self.input = [i for i in self.inputs][0]
-        self.output = [o for o in self.outputs][0]
+        # self.input = [i for i in self.inputs][0]
+        # self.output = [o for o in self.outputs][0]
 
 
 def storage_nominal_value_warning(flow):

--- a/oemof/solph/network.py
+++ b/oemof/solph/network.py
@@ -204,7 +204,7 @@ class LinearTransformer(on.Transformer):
             k: Sequence(v)
             for k, v in kwargs.get('conversion_factors', {}).items()}
 
-    def _input(self):
+    def input(self):
         """ Returns the first (and only) input of the storage object
         """
         return [i for i in self.inputs][0]
@@ -307,12 +307,12 @@ class Storage(on.Transformer):
                 if not isinstance(flow.investment, Investment):
                     flow.investment = Investment()
 
-    def _input(self):
+    def input(self):
         """ Returns the first (and only) input of the storage object
         """
         return [i for i in self.inputs][0]
 
-    def _output(self):
+    def output(self):
         """ Returns the first (and only) output of the storage object
         """
         return [o for o in self.outputs][0]

--- a/oemof/solph/network.py
+++ b/oemof/solph/network.py
@@ -10,7 +10,8 @@ from .plumbing import Sequence
 
 
 class EnergySystem(es.EnergySystem):
-    """ A variant of :class:`EnergySystem <oemof.core.energy_system.EnergySystem>` specially tailored to solph.
+    """ A variant of :class:`EnergySystem
+    <oemof.core.energy_system.EnergySystem>` specially tailored to solph.
 
     In order to work in tandem with solph, instances of this class always use
     :const:`solph.GROUPINGS <oemof.solph.GROUPINGS>`. If custom groupings are
@@ -23,13 +24,13 @@ class EnergySystem(es.EnergySystem):
     directly.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         # Doing imports at runtime is generally frowned upon, but should work
         # for now. See the TODO in :func:`constraint_grouping
         # <oemof.solph.groupings.constraint_grouping>` for more information.
         from . import GROUPINGS
         kwargs['groupings'] = GROUPINGS + kwargs.get('groupings', [])
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
 
 class Flow:
@@ -223,7 +224,7 @@ class Storage(on.Transformer):
     nominal_input_capacity_ratio : numeric
         see: nominal_output_capacity_ratio
     initial_capacity : numeric
-        The capacity of the storage in the first (and last) timestep of
+        The capacity of the storage in the first (and last) time step of
         optimization.
     capacity_loss : numeric (sequence or scalar)
         The relative loss of the storage capacity from between two consecutive
@@ -236,7 +237,7 @@ class Storage(on.Transformer):
     capacity_min : numeric (sequence or scalar)
         The nominal minimum capacity of the storage as fraction of the
         nominal capacity (between 0 and 1, default: 0).
-        To set different values in every timestep use a sequence.
+        To set different values in every time step use a sequence.
     capacity_max : numeric (sequence or scalar)
         see: capacity_min
     investment : :class:`oemof.solph.options.Investment` object

--- a/oemof/solph/network.py
+++ b/oemof/solph/network.py
@@ -189,8 +189,10 @@ class LinearTransformer(on.Transformer):
 
     >>> bel = Bus()
     >>> bth = Bus()
+    >>> bng = Bus()
     >>> trsf = LinearTransformer(conversion_factors={bel: 0.4,
-    ...                                              bth: [1, 2, 3]})
+    ...                                              bth: [1, 2, 3]},
+    ...                          inputs={bng: Flow()})
     >>> trsf.conversion_factors[bel][3]
     0.4
 


### PR DESCRIPTION
I think it would be faster if the methods are changed to attributes. As I understand it a methods like `_input` will search for the input flow every time it is called. If it is an attribute it will be done once. These attributes are needed when the constraints are build in the blocks module. If we use them inside rules they are called 8760 times (or more). 

Furthermore I do not understand why do use protected methods as we do want to use them in other modules and classes that are not child classes.