### PR TITLE
Features/addtional flow attributes in NodesFromCSV

### DIFF
--- a/doc/whatsnew/v0-1-2.rst
+++ b/doc/whatsnew/v0-1-2.rst
@@ -11,7 +11,7 @@ API changes
 New features
 ############
 
-
+* Allow to set addtional flow attributes inside NodesFromCSV in solph inputlib
 
 
 Documentation
@@ -40,6 +40,6 @@ Other changes
 Contributors
 ############
  
- * First
+ * Simon Hilpert
  * Second
 

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -11,7 +11,7 @@ from ..network import (Bus, Source, Sink, Flow, LinearTransformer, Storage)
 
 def NodesFromCSV(file_nodes_flows, file_nodes_flows_sequences,
                  delimiter=',', additional_classes={},
-                 additional_seq_attributes=[]):
+                 additional_seq_attributes=[], addtional_flow_attributes=[]):
     """ Creates nodes with their respective flows and sequences from
     a pre-defined CSV structure. An example has been provided in the
     development examples
@@ -60,7 +60,7 @@ def NodesFromCSV(file_nodes_flows, file_nodes_flows_sequences,
                       'capacity_min'] + additional_seq_attributes
 
     # attributes of different classes
-    flow_attrs = vars(Flow()).keys()
+    flow_attrs = list(vars(Flow()).keys()) + addtional_flow_attributes
     bus_attrs = vars(Bus()).keys()
 
     # iteration over dataframe rows to create objects

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -30,6 +30,9 @@ def NodesFromCSV(file_nodes_flows, file_nodes_flows_sequences,
     additional_seq_attributes : list
         List of string with attributes that have to be of type 'solph sequence'
         and that shall be recognized inside the csv file.
+    addational_flow_attributes : list
+        List of string with attributes that shall be recognized inside the
+        csv file and set as flow attribute
 
     """
 


### PR DESCRIPTION
At one point we might also just use ad dictionary with keys for specific attributes: 

```
addtional_attributes = {'flow': [], 'seq': [], 'bus' =[]} 
```

But this would change the API, so for now just adding an attribute