### PR TITLE
Economics module in tools

### DIFF
--- a/doc/whatsnew/v0-1-2.rst
+++ b/doc/whatsnew/v0-1-2.rst
@@ -14,7 +14,7 @@ New features
 * Allow to set addtional flow attributes inside NodesFromCSV in solph inputlib
 * Add module to store input data in multiple csv files and merge by 
 preprocessing
-
+* Add economics module to calculate investment annuities (more to come in future  versions)
 Documentation
 #############
 

--- a/examples/solph/storage_investment/storage_investment.py
+++ b/examples/solph/storage_investment/storage_investment.py
@@ -37,6 +37,7 @@ from oemof import outputlib
 # Default logger of oemof
 from oemof.tools import logger
 from oemof.tools import helpers
+from oemof.tools import economics
 import oemof.solph as solph
 
 # import oemof base classes to create energy system objects
@@ -102,11 +103,9 @@ def optimise_storage_size(filename="storage_investment.csv", solver='cbc',
         outputs={bel: solph.Flow(nominal_value=10e10, variable_costs=50)},
         conversion_factors={bel: 0.58})
 
-    # Calculate ep_costs from capex to compare with old solph
-    capex = 1000
-    lifetime = 20
-    wacc = 0.05
-    epc = capex * (wacc * (1 + wacc) ** lifetime) / ((1 + wacc) ** lifetime - 1)
+    # If the period is one year the equivalent periodical costs (epc) of an
+    # investment are equal to the annuity. Use oemof's economic tools.
+    epc = economics.annuity(capex=1000, n=20, wacc=0.05)
 
     # create storage transformer object for storage
     solph.Storage(

--- a/oemof/tools/economics.py
+++ b/oemof/tools/economics.py
@@ -4,12 +4,13 @@ Module to collect useful functions for economic calculation.
 
 """
 
+
 def annuity(capex, n, wacc):
     """
     Parameters
     ----------
     capex : float
-        Captial expenditure (NPV of investment)
+        Capital expenditure (NPV of investment)
     n : int
         Number of years that the investment is used (economic lifetime)
     wacc : float

--- a/oemof/tools/economics.py
+++ b/oemof/tools/economics.py
@@ -6,5 +6,14 @@ Module to collect useful functions for economic calculation.
 
 def annuity(capex, n, wacc):
     """
+    Parameters
+    ----------
+    capex : float
+        Captial expenditure (NPV of investment)
+    n : int
+        Number of years that the investment is used (economic lifetime)
+    wacc : float
+        Weighted average cost of capital
+
     """
     return capex * (wacc * (1 + wacc) ** n) / ((1 + wacc) ** n - 1)

--- a/oemof/tools/economics.py
+++ b/oemof/tools/economics.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""
+Module to collect useful functions for economic calculation.
+
+"""
+
+def annuity(capex, n, wacc):
+    """
+    """
+    return capex * (wacc * (1 + wacc) ** n) / ((1 + wacc) ** n - 1)


### PR DESCRIPTION
Some economic calculations are frequently used. I added a module to tools as suggested by @uvchik . 

We might want to add calculations based on the results structure of the oemof core layer, e.g. calculating LOC etc.