### PR TITLE
Add method to slice a balance around a bus

### DIFF
--- a/oemof/outputlib/__init__.py
+++ b/oemof/outputlib/__init__.py
@@ -186,10 +186,7 @@ class ResultsDataFrame(pd.DataFrame):
         outputs = self.slice_unstacked(bus_label=kwargs['bus_label'],
                                        type='from_bus',
                                        formatted=True)
-        other = self.slice_unstacked(bus_label=kwargs['bus_label'],
-                                     type='other',
-                                     formatted=True)
-        subset = pd.concat([inputs, outputs, other], axis=1)
+        subset = pd.concat([inputs, outputs], axis=1)
         return subset
 
 

--- a/oemof/outputlib/__init__.py
+++ b/oemof/outputlib/__init__.py
@@ -171,7 +171,7 @@ class ResultsDataFrame(pd.DataFrame):
         subset.columns = subset.columns.get_level_values(1).unique()
         return subset
 
-    def slice_bus_balance(self, **kwargs):
+    def slice_bus_balance(self, bus_label):
         r"""Method for slicing the ResultsDataFrame. An balance around a bus
         with inputs, outputs and other values is returned.
 
@@ -182,7 +182,7 @@ class ResultsDataFrame(pd.DataFrame):
         """
         dfs = []
         for l in self.index.levels[1]:
-            df = self.slice_unstacked(bus_label=kwargs['bus_label'], type=l,
+            df = self.slice_unstacked(bus_label=bus_label, type=l,
                                       formatted=True)
             dfs.append(df)
         subset = pd.concat(dfs, axis=1)

--- a/oemof/outputlib/__init__.py
+++ b/oemof/outputlib/__init__.py
@@ -160,7 +160,7 @@ class ResultsDataFrame(pd.DataFrame):
         unstacklevel : string (default: 'obj_label')
             Level to unstack the subset of the DataFrame.
         formatted : boolean
-            missing...
+
         """
         subset = self.slice_by(**kwargs)
         subset = subset.unstack(level=unstacklevel)
@@ -169,6 +169,27 @@ class ResultsDataFrame(pd.DataFrame):
                                inplace=True)
         # user standard instead of multi-indexed columns
         subset.columns = subset.columns.get_level_values(1).unique()
+        return subset
+
+    def slice_bus_balance(self, **kwargs):
+        r"""Method for slicing the ResultsDataFrame. An balance around a bus
+        with inputs, outputs and other values is returned.
+
+        Parameters
+        ----------
+        bus_label : string
+
+        """
+        inputs = self.slice_unstacked(bus_label=kwargs['bus_label'],
+                                      type='to_bus',
+                                      formatted=True)
+        outputs = self.slice_unstacked(bus_label=kwargs['bus_label'],
+                                       type='from_bus',
+                                       formatted=True)
+        other = self.slice_unstacked(bus_label=kwargs['bus_label'],
+                                     type='other',
+                                     formatted=True)
+        subset = pd.concat([inputs, outputs, other], axis=1)
         return subset
 
 

--- a/oemof/outputlib/__init__.py
+++ b/oemof/outputlib/__init__.py
@@ -180,13 +180,12 @@ class ResultsDataFrame(pd.DataFrame):
         bus_label : string
 
         """
-        inputs = self.slice_unstacked(bus_label=kwargs['bus_label'],
-                                      type='to_bus',
+        dfs = []
+        for l in self.index.levels[1]:
+            df = self.slice_unstacked(bus_label=kwargs['bus_label'], type=l,
                                       formatted=True)
-        outputs = self.slice_unstacked(bus_label=kwargs['bus_label'],
-                                       type='from_bus',
-                                       formatted=True)
-        subset = pd.concat([inputs, outputs], axis=1)
+            dfs.append(df)
+        subset = pd.concat(dfs, axis=1)
         return subset
 
 


### PR DESCRIPTION
I have added a method to slice inputs/outputs/other around busses as is seems to be a common subset to be extracted from the RDF.

TODOs:

* Update WHATSNEW
* Check docstrings

Could you check and give some feedback?