### PR TITLE
Transfer csv reader to scenario class

### DIFF
--- a/oemof/solph/__init__.py
+++ b/oemof/solph/__init__.py
@@ -10,3 +10,4 @@ from oemof.solph.models import OperationalModel
 from oemof.solph.groupings import GROUPINGS
 from oemof.solph.options import (Investment, BinaryFlow, DiscreteFlow)
 from oemof.solph.inputlib.csv_tools import NodesFromCSV
+from oemof.solph.inputlib.csv_tools import Scenario

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -19,9 +19,10 @@ PARAMETER = (
 INDEX = ('class', 'label', 'source', 'target')
 
 
-class SolphScenario:
+class SolphScenario(EnergySystem):
 
     def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self.p = kwargs.get('parameters')
         self.s = kwargs.get('sequences')
         self.path = kwargs.get('path', path.dirname(path.realpath(__file__)))

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -2,6 +2,7 @@
 
 import pandas as pd
 import os
+import warnings
 import os.path as path
 import logging
 from oemof import network
@@ -423,6 +424,9 @@ def NodesFromCSV(file_nodes_flows, file_nodes_flows_sequences, delimiter=',',
     delimiter : str
         Delimiter of CSV file
     """
+    msg = ("\nNodesFromCSV will be removed in oemof v0.2.0. " +
+           "\nUse the 'create_nodes' method of the 'Scenario' class instead.")
+    warnings.warn(msg, FutureWarning)
     nodes_flows = pd.read_csv(file_nodes_flows, sep=delimiter)
     nodes_flows_seq = pd.read_csv(file_nodes_flows_sequences,
                                   sep=delimiter, header=None)
@@ -448,6 +452,9 @@ def merge_csv_files(path=None, output_path=None, write=True):
     -------
     Tuple of dataframes (nodes_flows, nodes_flows_seq)
     """
+    msg = ("\nmerge_csv_files will be removed in oemof v0.2.0. " +
+           "\nUse pandas.concat and the 'Scenario' class instead.")
+    warnings.warn(msg, FutureWarning)
     if output_path is None:
         output_path = path
 
@@ -509,6 +516,10 @@ def resample_sequence(seq_base_file=None, output_path=None,
     header : list
         List of integers to specifiy the header lines
     """
+    msg = ("\nmerge_csv_files will be removed in oemof v0.2.0. " +
+           "\nUse pandas.DataFrame.reindex and the 'Scenario' class instead.")
+    warnings.warn(msg, FutureWarning)
+
     if samples is None:
         raise ValueError('Missing sample attribute. Please specifiy!')
     if output_path is None:

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -473,9 +473,9 @@ def NodesFromCSV(file_nodes_flows, file_nodes_flows_sequences, delimiter=',',
     delimiter : str
         Delimiter of CSV file
     """
-    msg = ("\nNodesFromCSV will be removed in oemof v0.2.0. " +
-           "\nUse the 'create_nodes' method of the 'Scenario' class instead.")
-    warnings.warn(msg, FutureWarning)
+    # msg = ("\nNodesFromCSV will be removed in oemof v0.2.0. " +
+    #        "\nUse the 'create_nodes' method of the 'Scenario' class instead.")
+    # warnings.warn(msg, FutureWarning)
     nodes_flows = pd.read_csv(file_nodes_flows, sep=delimiter)
     nodes_flows_seq = pd.read_csv(file_nodes_flows_sequences,
                                   sep=delimiter, header=None)

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -56,12 +56,14 @@ class Scenario:
     >>> my_es.add(nodes)  # doctest: +SKIP
     """
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.p = kwargs.get('parameters')
-        self.s = kwargs.get('sequences')
-        self.path = kwargs.get('path', path.dirname(path.realpath(__file__)))
-        self.name = kwargs.get('name')
+    def __init__(self, scenario_path=None, name=None, p=None, s=None):
+        logging.warning(
+            "Scenario class is still experimental. API may change frequently.")
+        if scenario_path is None:
+            self.scenario_path = path.dirname(path.realpath(__file__))
+        self.name = name
+        self.p = p
+        self.s = s
 
     def create_parameter_table(self, additional_parameter=None):
         """Create an empty parameter table."""

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -39,15 +39,10 @@ class SolphScenario(EnergySystem):
         self.p = pd.DataFrame(columns=PARAMETER + tuple(additional_parameter),
                               index=my_index)
 
-    def create_sequence_table(self, datetime_index=None, year=None,
-                              interval=None):
+    def create_sequence_table(self, datetime_index=None):
         """Create an empty sequence table."""
-        if interval is None:
-            interval = '60min'
         if datetime_index is None:
-            date_from = '{0}-01-01 00:00:00'.format(year)
-            date_to = '{0}-12-31 23:00:00'.format(year)
-            datetime_index = pd.date_range(date_from, date_to, freq=interval)
+            datetime_index = self.timeindex
 
         my_index = pd.MultiIndex(
             levels=[[1], [2], [3], [4], [5]], labels=[[0], [0], [0], [0], [0]],
@@ -61,9 +56,7 @@ class SolphScenario(EnergySystem):
         """Create empty scenario tables (sequence and parameter)."""
         self.create_parameter_table(
             additional_parameter=kwargs.get('additional_parameter'))
-        self.create_sequence_table(datetime_index=kwargs.get('datetime_index'),
-                                   year=kwargs.get('year'),
-                                   interval=kwargs.get('interval'))
+        self.create_sequence_table(datetime_index=kwargs.get('datetime_index'))
 
     def read_parameter_table(self, filename=None):
         """Read existing parameter table from file."""
@@ -78,14 +71,10 @@ class SolphScenario(EnergySystem):
         self.s = pd.read_csv(filename, header=[0, 1, 2, 3, 4], parse_dates=True,
                              index_col=0)
 
-    def read_tables(self, name=None, scenario_path=None):
+    def read_tables(self, parameterfile=None, sequencefile=None):
         """Read existing scenario tables (parameter and sequence)"""
-        if name is not None:
-            self.name = name
-        if scenario_path is not None:
-            self.path = scenario_path
-        self.read_parameter_table()
-        self.read_sequence_table()
+        self.read_parameter_table(parameterfile)
+        self.read_sequence_table(sequencefile)
 
     def write_parameter_table(self, filename=None):
         """Write parameter table to file."""
@@ -101,14 +90,10 @@ class SolphScenario(EnergySystem):
             filename = path.join(self.path, self.name + '_seq.csv')
         self.s.to_csv(filename)
 
-    def write_tables(self, name=None, scenario_path=None):
+    def write_tables(self, parameterfile=None, sequencefile=None):
         """Write scenario tables into two separate files."""
-        if name is not None:
-            self.name = name
-        if scenario_path is not None:
-            self.path = scenario_path
-        self.write_parameter_table()
-        self.write_sequence_table()
+        self.write_parameter_table(parameterfile)
+        self.write_sequence_table(sequencefile)
 
     def create_nodes(self):
         """
@@ -403,7 +388,7 @@ def nodes_from_csv(file_nodes_flows=None, file_nodes_flows_sequences=None,
             # inputs, outputs and conversion_factors
             inputs = function3(row, nodes, flow, bus_attrs, 'target', 'source',
                                i)
-            
+
             outputs = function3(row, nodes, flow, bus_attrs, 'source', 'target',
                                 i)
 

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -7,7 +7,8 @@ import logging
 from oemof import network
 from ..options import BinaryFlow, Investment
 from ..plumbing import sequence
-from ..network import (Bus, Source, Sink, Flow, LinearTransformer, Storage)
+from ..network import (Bus, Source, Sink, Flow, LinearTransformer, Storage,
+                       EnergySystem)
 
 
 PARAMETER = (

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -289,6 +289,11 @@ def function4(row, nodes, nodes_flows_seq, i):
     return conversion_factors
 
 
+def NodesFromCSV(file_nodes_flows, file_nodes_flows_sequences, **kwargs):
+    """Keep old name to keep the API."""
+    nodes_from_csv(file_nodes_flows, file_nodes_flows_sequences, **kwargs)
+
+
 def nodes_from_csv(file_nodes_flows=None, file_nodes_flows_sequences=None,
                    nodes_flows=None, nodes_flows_seq=None, delimiter=',',
                    additional_classes=None, additional_seq_attributes=None,

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -77,7 +77,14 @@ class Scenario:
                               index=my_index)
 
     def create_sequence_table(self, datetime_index):
-        """Create an empty sequence table."""
+        """
+        Create an empty sequence table.
+        
+        Parameters
+        ----------
+        datetime_index : pandas.DatetimeIndex
+            Datetime index.
+        """
         my_index = pd.MultiIndex(
             levels=[[1], [2], [3], [4], [5]], labels=[[0], [0], [0], [0], [0]],
             names=INDEX + ('attributes',))
@@ -86,8 +93,14 @@ class Scenario:
         del df[1, 2, 3, 4, 5]
         self.s = df
 
-    def create_tables(self, **kwargs):
-        """Create empty scenario tables (sequence and parameter)."""
+    def create_tables(self, datetime_index, **kwargs):
+        """Create empty scenario tables (sequence and parameter).
+                
+        Parameters
+        ----------
+        datetime_index : pandas.DatetimeIndex
+            Datetime index.
+        """
         self.create_parameter_table(
             additional_parameter=kwargs.get('additional_parameter'))
         self.create_sequence_table(datetime_index=kwargs.get('datetime_index'))

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -289,16 +289,18 @@ def function4(row, nodes, nodes_flows_seq, i):
     return conversion_factors
 
 
-def NodesFromCSV(file_nodes_flows, file_nodes_flows_sequences,
-                 delimiter=',', additional_classes=None,
-                 additional_seq_attributes=None,
-                 additional_flow_attributes=None):
+def nodes_from_csv(file_nodes_flows=None, file_nodes_flows_sequences=None,
+                   nodes_flows=None, nodes_flows_seq=None, delimiter=',',
+                   additional_classes=None, additional_seq_attributes=None,
+                   additional_flow_attributes=None):
     """ Creates nodes with their respective flows and sequences from
     a pre-defined CSV structure. An example has been provided in the
     development examples
 
     Parameters
     ----------
+    nodes_flows_seq : pandas.DataFrame
+    nodes_flows : pandas.DataFrame
     file_nodes_flows : string
         Name of CSV file with nodes and flows
     file_nodes_flows_sequences : string
@@ -324,16 +326,19 @@ def NodesFromCSV(file_nodes_flows, file_nodes_flows_sequences,
     if additional_flow_attributes is None:
         additional_flow_attributes = list()
 
-    # dataframe creation and manipulation
-    nodes_flows = pd.read_csv(file_nodes_flows, sep=delimiter)
-    nodes_flows_seq = pd.read_csv(file_nodes_flows_sequences, sep=delimiter,
-                                  header=None)
-    nodes_flows_seq.dropna(axis=0, how='all', inplace=True)
-    nodes_flows_seq.drop(0, axis=1, inplace=True)
-    nodes_flows_seq = nodes_flows_seq.transpose()
-    nodes_flows_seq.set_index([0, 1, 2, 3, 4], inplace=True)
-    nodes_flows_seq.columns = range(0, len(nodes_flows_seq.columns))
-    nodes_flows_seq = nodes_flows_seq.astype(float)
+    # DataFrame creation and manipulation
+    if nodes_flows is None:
+        nodes_flows = pd.read_csv(file_nodes_flows, sep=delimiter)
+
+    if nodes_flows_seq is None:
+        nodes_flows_seq = pd.read_csv(file_nodes_flows_sequences, sep=delimiter,
+                                      header=None)
+        nodes_flows_seq.dropna(axis=0, how='all', inplace=True)
+        nodes_flows_seq.drop(0, axis=1, inplace=True)
+        nodes_flows_seq = nodes_flows_seq.transpose()
+        nodes_flows_seq.set_index([0, 1, 2, 3, 4], inplace=True)
+        nodes_flows_seq.columns = range(0, len(nodes_flows_seq.columns))
+        nodes_flows_seq = nodes_flows_seq.astype(float)
 
     # class dictionary for dynamic instantiation
     classes = {'Source': Source, 'Sink': Sink,

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -9,6 +9,166 @@ from ..plumbing import sequence
 from ..network import (Bus, Source, Sink, Flow, LinearTransformer, Storage)
 
 
+def function1(row, nodes, classes, flow_attrs, seq_attributes, nodes_flows_seq,
+              i):
+    """
+    create node if not existent and set attributes
+    (attributes must be placed either in the first line or in all
+    lines of multiple node entries (flows) in csv file)
+    """
+    try:
+        if row['class'] in classes.keys():
+            node = nodes.get(row['label'])
+            if node is None:
+                node = classes[row['class']](label=row['label'])
+        # for the if check below we use all flow_attrs except
+        # investment
+        # because for storages investment needs to be set as a node
+        # attribute (and a flow attribute)
+        flow_attrs_ = [i for i in flow_attrs if i != 'investment']
+        for attr in row.keys():
+            if (attr not in flow_attrs_ and
+               attr not in ('class', 'label', 'source', 'target',
+                            'conversion_factors')):
+                    if row[attr] != 'seq':
+                        if attr in seq_attributes:
+                            row[attr] = sequence(float(row[attr]))
+                        # again from investment storage the next lines
+                        # are a little hacky as we need to create an
+                        # solph.options.Investment() object
+                        if (isinstance(node, Storage) and
+                                attr == 'investment'):
+                            setattr(node, attr, Investment())
+                            invest_attrs = vars(Investment()).keys()
+                            for iattr in invest_attrs:
+                                if iattr in row.keys() and row[attr]:
+                                    setattr(node.investment,
+                                            iattr, row[iattr])
+                        # for all 'normal' attributes
+                        else:
+                            setattr(node, attr, row[attr])
+
+                    else:
+                        seq = nodes_flows_seq.loc[row['class'],
+                                                  row['label'],
+                                                  row['source'],
+                                                  row['target'],
+                                                  attr]
+                        if attr in seq_attributes:
+                            seq = [i for i in seq]
+                            seq = sequence(seq)
+                        else:
+                            seq = [i for i in seq.values]
+                        setattr(node, attr, seq)
+    except:
+        print('Error with node creation in line', i+2, 'in csv file.')
+        print('Label:', row['label'])
+        raise
+    return node
+
+
+def function2(row, node, flow_attrs, seq_attributes, nodes_flows_seq, i):
+    """create flow and set attributes
+    """
+    try:
+        flow = Flow()
+        for attr in flow_attrs:
+            if attr in row.keys() and row[attr]:
+                if row[attr] != 'seq':
+                    if attr in seq_attributes:
+                        row[attr] = sequence(float(row[attr]))
+                    setattr(flow, attr, row[attr])
+                if row[attr] == 'seq':
+                    seq = nodes_flows_seq.loc[row['class'],
+                                              row['label'],
+                                              row['source'],
+                                              row['target'],
+                                              attr]
+                    if attr in seq_attributes:
+                        seq = [i for i in seq]
+                        seq = sequence(seq)
+                    else:
+                        seq = [i for i in seq.values]
+                    setattr(flow, attr, seq)
+                # this block is only for binary flows!
+                if attr == 'binary' and row[attr] is True:
+                    # create binary object for flow
+                    setattr(flow, attr, BinaryFlow())
+                    binary_attrs = vars(BinaryFlow()).keys()
+                    for battr in binary_attrs:
+                        if battr in row.keys() and row[attr]:
+                            setattr(flow.binary, battr, row[battr])
+                # this block is only for investment flows!
+                if attr == 'investment' and row[attr] is True:
+                    if isinstance(node, Storage):
+                        # set the flows of the storage to Investment as
+                        # without attributes, as costs etc are set at
+                        # the node
+                        setattr(flow, attr, Investment())
+                    else:
+                        # create binary object for flow
+                        setattr(flow, attr, Investment())
+                        invest_attrs = vars(Investment()).keys()
+                        for iattr in invest_attrs:
+                            if iattr in row.keys() and row[attr]:
+                                setattr(flow.investment, iattr,
+                                        row[iattr])
+    except:
+        print('Error with flow creation in line', i + 2, 'in csv file.')
+        print('Label:', row['label'])
+        raise
+    return flow
+
+
+def function3(row, nodes, flow, bus_attrs, type1, type2, i):
+    """create an output entry for the current lin
+    """
+    try:
+        if row['label'] == row[type1]:
+            if row[type2] not in nodes.keys():
+                nodes[row[type2]] = Bus(label=row[type2])
+                for attr in bus_attrs:
+                    if attr in row.keys() and row[attr] is not None:
+                        setattr(nodes[row[type2]], attr, row[attr])
+            tmp = {nodes[row[type2]]: flow}
+        else:
+            tmp = {}
+    except:
+        print('Error with output creation in line', i + 2,
+              'in csv file.')
+        print('Label:', row['label'])
+        raise
+    return tmp
+
+
+def function4(row, nodes, nodes_flows_seq, i):
+    """create a conversion_factor entry for the current lin
+    """
+    try:
+        if row['target'] and 'conversion_factors' in row:
+            if row['conversion_factors'] == 'seq':
+                seq = nodes_flows_seq.loc[row['class'],
+                                          row['label'],
+                                          row['source'],
+                                          row['target'],
+                                          'conversion_factors']
+                seq = [i for i in seq]
+                seq = sequence(seq)
+                conversion_factors = {nodes[row['target']]: seq}
+            else:
+                conversion_factors = {
+                    nodes[row['target']]:
+                        sequence(float(row['conversion_factors']))}
+        else:
+            conversion_factors = {}
+    except:
+        print('Error with conversion factor creation in line', i + 2,
+              'in csv file.')
+        print('Label:', row['label'])
+        raise
+    return conversion_factors
+
+
 def NodesFromCSV(file_nodes_flows, file_nodes_flows_sequences,
                  delimiter=',', additional_classes=None,
                  additional_seq_attributes=None,
@@ -85,163 +245,22 @@ def NodesFromCSV(file_nodes_flows, file_nodes_flows_sequences,
             # save column labels and row values in dict
             row = dict(zip(r.index.values, r.values))
 
-            # create node if not existent and set attributes
-            # (attributes must be placed either in the first line or in all
-            #  lines of multiple node entries (flows) in csv file)
-            try:
-                if row['class'] in classes.keys():
-                    node = nodes.get(row['label'])
-                    if node is None:
-                        node = classes[row['class']](label=row['label'])
-                # for the if check below we use all flow_attrs except
-                # investment
-                # because for storages investment needs to be set as a node
-                # attribute (and a flow attribute)
-                flow_attrs_ = [i for i in flow_attrs if i != 'investment']
-                for attr in row.keys():
-                    if (attr not in flow_attrs_ and
-                       attr not in ('class', 'label', 'source', 'target',
-                                    'conversion_factors')):
-                            if row[attr] != 'seq':
-                                if attr in seq_attributes:
-                                    row[attr] = sequence(float(row[attr]))
-                                # again from investment storage the next lines
-                                # are a little hacky as we need to create an
-                                # solph.options.Investment() object
-                                if (isinstance(node, Storage) and
-                                        attr == 'investment'):
-                                    setattr(node, attr, Investment())
-                                    invest_attrs = vars(Investment()).keys()
-                                    for iattr in invest_attrs:
-                                        if iattr in row.keys() and row[attr]:
-                                            setattr(node.investment,
-                                                    iattr, row[iattr])
-                                # for all 'normal' attributes
-                                else:
-                                    setattr(node, attr, row[attr])
-
-                            else:
-                                seq = nodes_flows_seq.loc[row['class'],
-                                                          row['label'],
-                                                          row['source'],
-                                                          row['target'],
-                                                          attr]
-                                if attr in seq_attributes:
-                                    seq = [i for i in seq]
-                                    seq = sequence(seq)
-                                else:
-                                    seq = [i for i in seq.values]
-                                setattr(node, attr, seq)
-            except:
-                print('Error with node creation in line', i+2, 'in csv file.')
-                print('Label:', row['label'])
-                raise
+            # function1
+            node = function1(row, nodes, classes, flow_attrs, seq_attributes,
+                             nodes_flows_seq, i)
 
             # create flow and set attributes
-            try:
-                flow = Flow()
-                for attr in flow_attrs:
-                    if attr in row.keys() and row[attr]:
-                        if row[attr] != 'seq':
-                            if attr in seq_attributes:
-                                row[attr] = sequence(float(row[attr]))
-                            setattr(flow, attr, row[attr])
-                        if row[attr] == 'seq':
-                            seq = nodes_flows_seq.loc[row['class'],
-                                                      row['label'],
-                                                      row['source'],
-                                                      row['target'],
-                                                      attr]
-                            if attr in seq_attributes:
-                                seq = [i for i in seq]
-                                seq = sequence(seq)
-                            else:
-                                seq = [i for i in seq.values]
-                            setattr(flow, attr, seq)
-                        # this block is only for binary flows!
-                        if attr == 'binary' and row[attr] is True:
-                            # create binary object for flow
-                            setattr(flow, attr, BinaryFlow())
-                            binary_attrs = vars(BinaryFlow()).keys()
-                            for battr in binary_attrs:
-                                if battr in row.keys() and row[attr]:
-                                    setattr(flow.binary, battr, row[battr])
-                        # this block is only for investment flows!
-                        if attr == 'investment' and row[attr] is True:
-                            if isinstance(node, Storage):
-                                # set the flows of the storage to Investment as
-                                # without attributes, as costs etc are set at
-                                # the node
-                                setattr(flow, attr, Investment())
-                            else:
-                                # create binary object for flow
-                                setattr(flow, attr, Investment())
-                                invest_attrs = vars(Investment()).keys()
-                                for iattr in invest_attrs:
-                                    if iattr in row.keys() and row[attr]:
-                                        setattr(flow.investment, iattr,
-                                                row[iattr])
-            except:
-                print('Error with flow creation in line', i+2, 'in csv file.')
-                print('Label:', row['label'])
-                raise
+            flow = function2(row, node, flow_attrs, seq_attributes,
+                             nodes_flows_seq, i)
 
-            # create an input entry for the current line
-            try:
-                if row['label'] == row['target']:
-                    if row['source'] not in nodes.keys():
-                        nodes[row['source']] = Bus(label=row['source'])
-                        for attr in bus_attrs:
-                            if attr in row.keys() and row[attr] is not None:
-                                setattr(nodes[row['source']], attr, row[attr])
-                    inputs = {nodes[row['source']]: flow}
-                else:
-                    inputs = {}
-            except:
-                print('Error with input creation in line', i+2, 'in csv file.')
-                print('Label:', row['label'])
-                raise
+            # inputs, outputs and conversion_factors
+            inputs = function3(row, nodes, flow, bus_attrs, 'target', 'source',
+                               i)
+            
+            outputs = function3(row, nodes, flow, bus_attrs, 'source', 'target',
+                                i)
 
-            # create an output entry for the current line
-            try:
-                if row['label'] == row['source']:
-                    if row['target'] not in nodes.keys():
-                        nodes[row['target']] = Bus(label=row['target'])
-                        for attr in bus_attrs:
-                            if attr in row.keys() and row[attr] is not None:
-                                setattr(nodes[row['target']], attr, row[attr])
-                    outputs = {nodes[row['target']]: flow}
-                else:
-                    outputs = {}
-            except:
-                print('Error with output creation in line', i+2,
-                      'in csv file.')
-                print('Label:', row['label'])
-                raise
-
-            # create a conversion_factor entry for the current line
-            try:
-                if row['target'] and 'conversion_factors' in row:
-                    if row['conversion_factors'] == 'seq':
-                        seq = nodes_flows_seq.loc[row['class'],
-                                                  row['label'],
-                                                  row['source'],
-                                                  row['target'],
-                                                  'conversion_factors']
-                        seq = [i for i in seq]
-                        seq = sequence(seq)
-                        conversion_factors = {nodes[row['target']]: seq}
-                    else:
-                        conversion_factors = \
-                            {nodes[row['target']]:
-                                sequence(float(row['conversion_factors']))}
-                else:
-                    conversion_factors = {}
-            except:
-                print('Error with conversion factor creation in line', i+2,
-                      'in csv file.')
-                print('Label:', row['label'])
-                raise
+            conversion_factors = function4(row, nodes, nodes_flows_seq, i)
 
             # add node to dict and assign attributes depending on
             # if there are multiple lines per node or not

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -120,8 +120,8 @@ class SolphScenario:
         self.p.loc[idx, columns] = values
         self.p = self.p.sortlevel()
 
-    def add_sequences(self, idx, sequence):
-        self.s[idx[0], idx[1], idx[2], idx[3], idx[4]] = sequence
+    def add_sequences(self, idx, seq):
+        self.s[idx[0], idx[1], idx[2], idx[3], idx[4]] = seq
 
     def add_comment_line(self, comment, sort_entry):
         self.p.loc[('### {0}'.format(comment), '', '', ''),

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -114,7 +114,7 @@ class SolphScenario(EnergySystem):
         tmp2.columns = list(range(length))
 
         # noinspection PyTypeChecker
-        return nodes_from_csv(
+        return nodes_from_df(
             nodes_flows=self.p.reset_index(),
             nodes_flows_seq=pd.concat([tmp1, tmp2], ignore_index=True),
             **kwargs)
@@ -303,10 +303,9 @@ def NodesFromCSV(file_nodes_flows, file_nodes_flows_sequences, **kwargs):
     nodes_from_csv(file_nodes_flows, file_nodes_flows_sequences, **kwargs)
 
 
-def nodes_from_csv(file_nodes_flows=None, file_nodes_flows_sequences=None,
-                   nodes_flows=None, nodes_flows_seq=None, delimiter=',',
-                   additional_classes=None, additional_seq_attributes=None,
-                   additional_flow_attributes=None):
+def nodes_from_df(nodes_flows, nodes_flows_seq, additional_classes=None,
+                  additional_seq_attributes=None,
+                  additional_flow_attributes=None):
     """ Creates nodes with their respective flows and sequences from
     a pre-defined CSV structure. An example has been provided in the
     development examples

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -60,6 +60,8 @@ class Scenario:
             "Scenario class is still experimental. API may change frequently.")
         if scenario_path is None:
             self.scenario_path = path.dirname(path.realpath(__file__))
+        else:
+            self.scenario_path = scenario_path
         self.name = name
         self.p = p
         self.s = s
@@ -360,6 +362,7 @@ def nodes_from_df(nodes_flows, nodes_flows_seq, additional_classes=None,
         tmp1 = pd.DataFrame(index=nodes_flows_seq.columns
                             ).reset_index().transpose().reset_index()
         tmp2 = nodes_flows_seq.reset_index()
+
         for n in range(len(tmp2.columns.levels) - 1):
             tmp2.columns = tmp2.columns.droplevel(0)
         length = len(tmp1.columns)

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -315,10 +315,10 @@ def nodes_from_df(nodes_flows, nodes_flows_seq, additional_classes=None,
         Dictionary containing additional classes to be recognized inside the
         csv reader. Looks like: {'MyClass1': MyClass1, ...}
     additional_seq_attributes : iterable
-        List of string with attributes that have to be of type 'solph sequence'
-        and that shall be recognized inside the csv file.
+        List of strings with attributes that have to be of type
+        'solph sequence' and that shall be recognized inside the csv file.
     additional_flow_attributes : iterable
-        List of string with attributes that shall be recognized inside the
+        List of strings with attributes that shall be recognized inside the
         csv file and set as flow attribute
     old_api : boolean
         DEPRECATED: Set to True if DataFrames in the old shape are passed.

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -21,6 +21,40 @@ INDEX = ('class', 'label', 'source', 'target')
 
 
 class Scenario:
+    """
+    EXPERIMENTAL. API may change frequently.
+    Defining an oemof energy system scenario.
+    
+    Parameters
+    ----------
+    scenario_path : str
+        Path where the scenario can be dumped. 
+    name : str
+        Name of the scenario. Will be the base part of the filename
+    p : pandas.DataFrame
+        oemof parameter table.
+    s : pandas.DataFrame
+        oemof sequence table.
+        
+    Examples
+    --------
+    Use the following example if you want to use the Scenario class instead of
+    the NodesFromCSV function.
+    
+    >>> import os
+    >>> import oemof.solph as solph
+    >>> my_path = os.path.join('my_folder', 'my_scenarios')
+    >>> my_name = 'cool_scenario_name'
+    >>> my_timeindex = pd.date_range('2012-01-01', '2012-12-31', freq='60min')
+    >>> my_scenario = solph.Scenario(scenario_path=my_path, name=my_name)
+    >>> # The following works if the files are named:
+    >>> # "cool_scenario_name.csv" and "cool_scenario_name_seq.csv"
+    >>> # Otherwise you have to pass the full path to the read_tables method. 
+    >>> my_scenario.read_tables()  # doctest: +SKIP
+    >>> nodes = my_scenario.create_nodes()  # doctest: +SKIP
+    >>> my_es = solph.EnergySystem(timeindex=my_timeindex)  # doctest: +SKIP
+    >>> my_es.add(nodes)  # doctest: +SKIP
+    """
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -103,18 +103,18 @@ class Scenario:
         """
         self.create_parameter_table(
             additional_parameter=kwargs.get('additional_parameter'))
-        self.create_sequence_table(datetime_index=kwargs.get('datetime_index'))
+        self.create_sequence_table(datetime_index)
 
     def read_parameter_table(self, filename=None):
         """Read existing parameter table from file."""
         if filename is None:
-            filename = path.join(self.path, self.name + '.csv')
+            filename = path.join(self.scenario_path, self.name + '.csv')
         self.p = pd.read_csv(filename, index_col=[0, 1, 2, 3])
 
     def read_sequence_table(self, filename=None):
         """Read existing parameter table from file."""
         if filename is None:
-            filename = path.join(self.path, self.name + '_seq.csv')
+            filename = path.join(self.scenario_path, self.name + '_seq.csv')
         self.s = pd.read_csv(filename, header=[0, 1, 2, 3, 4], parse_dates=True,
                              index_col=0)
 
@@ -126,14 +126,14 @@ class Scenario:
     def write_parameter_table(self, filename=None):
         """Write parameter table to file."""
         if filename is None:
-            filename = path.join(self.path, self.name + '.csv')
+            filename = path.join(self.scenario_path, self.name + '.csv')
         self.p.sort_values('sort_index', inplace=True)
         self.p.fillna('').to_csv(filename)
 
     def write_sequence_table(self, filename=None):
         """Write sequence table to file."""
         if filename is None:
-            filename = path.join(self.path, self.name + '_seq.csv')
+            filename = path.join(self.scenario_path, self.name + '_seq.csv')
         self.s.to_csv(filename)
 
     def write_tables(self, parameterfile=None, sequencefile=None):

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -8,8 +8,7 @@ import logging
 from oemof import network
 from ..options import BinaryFlow, Investment
 from ..plumbing import sequence
-from ..network import (Bus, Source, Sink, Flow, LinearTransformer, Storage,
-                       EnergySystem)
+from ..network import (Bus, Source, Sink, Flow, LinearTransformer, Storage)
 
 
 PARAMETER = (
@@ -21,7 +20,7 @@ PARAMETER = (
 INDEX = ('class', 'label', 'source', 'target')
 
 
-class SolphScenario(EnergySystem):
+class Scenario:
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -41,11 +40,8 @@ class SolphScenario(EnergySystem):
         self.p = pd.DataFrame(columns=PARAMETER + tuple(additional_parameter),
                               index=my_index)
 
-    def create_sequence_table(self, datetime_index=None):
+    def create_sequence_table(self, datetime_index):
         """Create an empty sequence table."""
-        if datetime_index is None:
-            datetime_index = self.timeindex
-
         my_index = pd.MultiIndex(
             levels=[[1], [2], [3], [4], [5]], labels=[[0], [0], [0], [0], [0]],
             names=INDEX + ('attributes',))

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -46,14 +46,13 @@ class Scenario:
     >>> my_path = os.path.join('my_folder', 'my_scenarios')
     >>> my_name = 'cool_scenario_name'
     >>> my_timeindex = pd.date_range('2012-01-01', '2012-12-31', freq='60min')
+    >>> my_es = solph.EnergySystem(timeindex=my_timeindex)
     >>> my_scenario = solph.Scenario(scenario_path=my_path, name=my_name)
     >>> # The following works if the files are named:
     >>> # "cool_scenario_name.csv" and "cool_scenario_name_seq.csv"
     >>> # Otherwise you have to pass the full path to the read_tables method. 
     >>> my_scenario.read_tables()  # doctest: +SKIP
-    >>> nodes = my_scenario.create_nodes()  # doctest: +SKIP
-    >>> my_es = solph.EnergySystem(timeindex=my_timeindex)  # doctest: +SKIP
-    >>> my_es.add(nodes)  # doctest: +SKIP
+    >>> my_scenario.create_nodes()  # doctest: +SKIP
     """
 
     def __init__(self, scenario_path=None, name=None, p=None, s=None):

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -57,6 +57,7 @@ class SolphScenario:
         self.s = df
 
     def create_tables(self, **kwargs):
+        """Create empty scenario tables (sequence and parameter)."""
         self.create_parameter_table(
             additional_parameter=kwargs.get('additional_parameter'))
         self.create_sequence_table(datetime_index=kwargs.get('datetime_index'),

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -140,29 +140,9 @@ class Scenario:
         self.write_parameter_table(parameterfile)
         self.write_sequence_table(sequencefile)
 
-    def create_nodes(self, **kwargs):
-        """
-        Create nodes for a solph.energysystem
-
-        Notes
-        -----
-        At the moment the nodes_from_csv function does not accept Multiindex
-        DataFrames therefore the DataFrames need to be reshaped.
-        """
-        tmp1 = pd.DataFrame(
-            index=self.s.columns).reset_index().transpose().reset_index()
-        tmp2 = self.s.reset_index()
-        for n in range(len(tmp2.columns.levels) - 1):
-            tmp2.columns = tmp2.columns.droplevel(0)
-        length = len(tmp1.columns)
-        tmp1.columns = list(range(length))
-        tmp2.columns = list(range(length))
-
-        # noinspection PyTypeChecker
-        return nodes_from_df(
-            nodes_flows=self.p.reset_index(),
-            nodes_flows_seq=pd.concat([tmp1, tmp2], ignore_index=True),
-            **kwargs)
+    def create_nodes(self):
+        """Create nodes for a solph.energysystem"""
+        return nodes_from_df(nodes_flows=self.p, nodes_flows_seq=self.s)
 
     def add_parameters(self, idx, columns, values):
         self.p.loc[idx, columns] = values

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -95,7 +95,7 @@ class SolphScenario(EnergySystem):
         self.write_parameter_table(parameterfile)
         self.write_sequence_table(sequencefile)
 
-    def create_nodes(self):
+    def create_nodes(self, **kwargs):
         """
         Create nodes for a solph.energysystem
 
@@ -116,7 +116,8 @@ class SolphScenario(EnergySystem):
         # noinspection PyTypeChecker
         return nodes_from_csv(
             nodes_flows=self.p.reset_index(),
-            nodes_flows_seq=pd.concat([tmp1, tmp2], ignore_index=True))
+            nodes_flows_seq=pd.concat([tmp1, tmp2], ignore_index=True),
+            **kwargs)
 
     def add_parameters(self, idx, columns, values):
         self.p.loc[idx, columns] = values

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -2,11 +2,131 @@
 
 import pandas as pd
 import os
+import os.path as path
 import logging
 from oemof import network
 from ..options import BinaryFlow, Investment
 from ..plumbing import sequence
 from ..network import (Bus, Source, Sink, Flow, LinearTransformer, Storage)
+
+
+PARAMETER = (
+    'conversion_factors', 'nominal_value',
+    'min', 'max', 'summed_max', 'actual_value', 'fixed_costs', 'variable_costs',
+    'fixed', 'nominal_capacity', 'capacity_loss', 'inflow_conversion_factor',
+    'outflow_conversion_factor', 'initial_capacity', 'capacity_min',
+    'capacity_max', 'balanced', 'sort_index')
+INDEX = ('class', 'label', 'source', 'target')
+
+
+class SolphScenario:
+
+    def __init__(self, **kwargs):
+        self.p = kwargs.get('parameters')
+        self.s = kwargs.get('sequences')
+        self.path = kwargs.get('path', path.dirname(path.realpath(__file__)))
+        self.name = kwargs.get('name')
+
+    def create_parameter_table(self, additional_parameter=None):
+        """Create an empty parameter table."""
+        if additional_parameter is None:
+            additional_parameter = tuple()
+
+        my_index = pd.MultiIndex(levels=[[], [], [], []],
+                                 labels=[[], [], [], []],
+                                 names=INDEX)
+        self.p = pd.DataFrame(columns=PARAMETER + tuple(additional_parameter),
+                              index=my_index)
+
+    def create_sequence_table(self, datetime_index=None, year=None,
+                              interval=None):
+        """Create an empty sequence table."""
+        if interval is None:
+            interval = '60min'
+        if datetime_index is None:
+            date_from = '{0}-01-01 00:00:00'.format(year)
+            date_to = '{0}-12-31 23:00:00'.format(year)
+            datetime_index = pd.date_range(date_from, date_to, freq=interval)
+
+        my_index = pd.MultiIndex(
+            levels=[[1], [2], [3], [4], [5]], labels=[[0], [0], [0], [0], [0]],
+            names=INDEX + ('attributes',))
+
+        df = pd.DataFrame(index=datetime_index, columns=my_index)
+        del df[1, 2, 3, 4, 5]
+        self.s = df
+
+    def create_tables(self, **kwargs):
+        self.create_parameter_table(
+            additional_parameter=kwargs.get('additional_parameter'))
+        self.create_sequence_table(datetime_index=kwargs.get('datetime_index'),
+                                   year=kwargs.get('year'),
+                                   interval=kwargs.get('interval'))
+
+    def read_parameter_table(self, filename=None):
+        """Read existing parameter table from file."""
+        if filename is None:
+            filename = path.join(self.path, self.name + '.csv')
+        self.p = pd.read_csv(filename, index_col=[0, 1, 2, 3])
+
+    def read_sequence_table(self, filename=None):
+        """Read existing parameter table from file."""
+        if filename is None:
+            filename = path.join(self.path, self.name + '_seq_.csv')
+        self.s = pd.read_csv(filename, header=[0, 1, 2, 3, 4], parse_dates=True,
+                             index_col=0)
+
+    def read_tables(self, name=None, scenario_path=None):
+        """Read existing scenario tables (parameter and sequence)"""
+        if name is not None:
+            self.name = name
+        if scenario_path is not None:
+            self.path = scenario_path
+        self.read_parameter_table()
+        self.read_sequence_table()
+
+    def write_parameter_table(self, filename=None):
+        """Write parameter table to file."""
+        if filename is None:
+            filename = path.join(self.path, self.name + '.csv')
+        self.p = self.p.fillna('')
+        self.p.sort_values('sort_index', inplace=True)
+        self.p.to_csv(filename)
+
+    def write_sequence_table(self, filename=None):
+        """Write sequence table to file."""
+        if filename is None:
+            filename = path.join(self.path, self.name + '_seq.csv')
+        self.s.to_csv(filename)
+
+    def write_tables(self, name=None, scenario_path=None):
+        """Write scenario tables into two separate files."""
+        if name is not None:
+            self.name = name
+        if scenario_path is not None:
+            self.path = scenario_path
+        self.write_parameter_table()
+        self.write_sequence_table()
+
+    def create_nodes(self):
+        """Create nodes for a solph.energysystem."""
+        # Todo: self.p and self.s has to be adapt to have the shape needed by
+        # Todo: the 'nodes_from_csv' function.
+        df_p = self.p
+        df_s = self.s
+        nodes_from_csv(nodes_flows=df_p, nodes_flows_seq=df_s)
+
+    def add_parameters(self, idx, columns, values):
+        self.p.loc[idx, columns] = values
+        self.p = self.p.sortlevel()
+
+    def add_sequences(self, idx, sequence):
+        self.s[idx[0], idx[1], idx[2], idx[3], idx[4]] = sequence
+
+    def add_comment_line(self, comment, sort_entry):
+        self.p.loc[('### {0}'.format(comment), '', '', ''),
+                   'sort_index'] = sort_entry
+        self.p = self.p.sortlevel()
 
 
 def function1(row, nodes, classes, flow_attrs, seq_attributes, nodes_flows_seq,

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -134,9 +134,10 @@ class SolphScenario(EnergySystem):
 def create_node(row, nodes, classes, flow_attrs, seq_attributes,
                 nodes_flows_seq, i):
     """
-    create node if not existent and set attributes for the current line
+    Create node if not existent and set attributes for the current line
     (attributes must be placed either in the first line or in all
-    lines of multiple node entries (flows) in csv file)
+    lines of multiple node entries (flows) in csv file and be unique
+    to assign them either to a node or flow object)
     """
     try:
         if row['class'] in classes.keys():
@@ -189,7 +190,9 @@ def create_node(row, nodes, classes, flow_attrs, seq_attributes,
 
 
 def create_flow(row, node, flow_attrs, seq_attributes, nodes_flows_seq, i):
-    """create flow and set attributes for the current line
+    """
+    Create flow and set attributes for the current line
+    (based on attributes that only belong to the flow object)
     """
     try:
         flow = Flow()
@@ -242,7 +245,10 @@ def create_flow(row, node, flow_attrs, seq_attributes, nodes_flows_seq, i):
 
 
 def create_output_entry(row, nodes, flow, bus_attrs, type1, type2, i):
-    """create an output entry for the current line"""
+    """
+    Create an output entry for the current line
+    (a dict for the nodes outputs of type {node1: flow1, node2: flow2})
+    """
     try:
         if row['label'] == row[type1]:
             if row[type2] not in nodes.keys():
@@ -262,7 +268,10 @@ def create_output_entry(row, nodes, flow, bus_attrs, type1, type2, i):
 
 
 def create_conversion_factors(row, nodes, nodes_flows_seq, i):
-    """create a conversion_factor entry for the current line"""
+    """
+    Create a conversion_factor entry for the current line
+    (a dict for the conversion factors of type {node1: eta1, node2: eta2})
+    """
     try:
         if row['target'] and 'conversion_factors' in row:
             if row['conversion_factors'] == 'seq':

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -72,7 +72,7 @@ class SolphScenario:
     def read_sequence_table(self, filename=None):
         """Read existing parameter table from file."""
         if filename is None:
-            filename = path.join(self.path, self.name + '_seq_.csv')
+            filename = path.join(self.path, self.name + '_seq.csv')
         self.s = pd.read_csv(filename, header=[0, 1, 2, 3, 4], parse_dates=True,
                              index_col=0)
 

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -80,9 +80,8 @@ class SolphScenario(EnergySystem):
         """Write parameter table to file."""
         if filename is None:
             filename = path.join(self.path, self.name + '.csv')
-        self.p = self.p.fillna('')
         self.p.sort_values('sort_index', inplace=True)
-        self.p.to_csv(filename)
+        self.p.fillna('').to_csv(filename)
 
     def write_sequence_table(self, filename=None):
         """Write sequence table to file."""
@@ -367,7 +366,6 @@ def nodes_from_csv(file_nodes_flows=None, file_nodes_flows_sequences=None,
     # iteration over dataframe rows to create objects
     nodes = {}
     for i, r in nodes_flows.iterrows():
-
         # check if current line holds valid data or is just for visual purposes
         # e.g. a blank line or a line that contains data explanations
         if isinstance(r['class'], str) and r['class'] in classes.keys():

--- a/oemof/solph/inputlib/csv_tools.py
+++ b/oemof/solph/inputlib/csv_tools.py
@@ -298,11 +298,6 @@ def create_conversion_factors(row, nodes, nodes_flows_seq, i):
     return conversion_factors
 
 
-def NodesFromCSV(file_nodes_flows, file_nodes_flows_sequences, **kwargs):
-    """Keep old name to keep the API."""
-    nodes_from_csv(file_nodes_flows, file_nodes_flows_sequences, **kwargs)
-
-
 def nodes_from_df(nodes_flows, nodes_flows_seq, additional_classes=None,
                   additional_seq_attributes=None,
                   additional_flow_attributes=None):
@@ -314,12 +309,6 @@ def nodes_from_df(nodes_flows, nodes_flows_seq, additional_classes=None,
     ----------
     nodes_flows_seq : pandas.DataFrame
     nodes_flows : pandas.DataFrame
-    file_nodes_flows : string
-        Name of CSV file with nodes and flows
-    file_nodes_flows_sequences : string
-        Name of of CSV file containing sequences
-    delimiter : str
-        Delimiter of CSV file
     additional_classes : dict
         Dictionary containing additional classes to be recognized inside the
         csv reader. Looks like: {'MyClass1': MyClass1, ...}
@@ -340,12 +329,6 @@ def nodes_from_df(nodes_flows, nodes_flows_seq, additional_classes=None,
         additional_flow_attributes = list()
 
     # DataFrame creation and manipulation
-    if nodes_flows is None:
-        nodes_flows = pd.read_csv(file_nodes_flows, sep=delimiter)
-
-    if nodes_flows_seq is None:
-        nodes_flows_seq = pd.read_csv(file_nodes_flows_sequences,
-                                      sep=delimiter, header=None)
     nodes_flows_seq.dropna(axis=0, how='all', inplace=True)
     nodes_flows_seq.drop(0, axis=1, inplace=True)
     nodes_flows_seq = nodes_flows_seq.transpose()
@@ -421,6 +404,29 @@ def nodes_from_df(nodes_flows, nodes_flows_seq, additional_classes=None,
                 raise
 
     return nodes
+
+# **************** deprecated *************************************************
+
+
+def NodesFromCSV(file_nodes_flows, file_nodes_flows_sequences, delimiter=',',
+                 **kwargs):
+    """ Creates nodes with their respective flows and sequences from
+    a pre-defined CSV structure. An example has been provided in the
+    development examples
+
+    Parameters
+    ----------
+    file_nodes_flows : string
+        Name of CSV file with nodes and flows
+    file_nodes_flows_sequences : string
+        Name of of CSV file containing sequences
+    delimiter : str
+        Delimiter of CSV file
+    """
+    nodes_flows = pd.read_csv(file_nodes_flows, sep=delimiter)
+    nodes_flows_seq = pd.read_csv(file_nodes_flows_sequences,
+                                  sep=delimiter, header=None)
+    nodes_from_df(nodes_flows, nodes_flows_seq, **kwargs)
 
 
 def merge_csv_files(path=None, output_path=None, write=True):


### PR DESCRIPTION
The main idea is to place the pandas DataFrame in the centre of the class and not the csv-file.

1. I would like to divide the NodesFromCSV function into sub functions to improve the readability of the csv-reader . Then it might be easier to improve parts of the functions. So I created some subfunctions. @ckaldemeyer, @simnh or @s3pp : May you rename the functions and add 1-5 lines to the docstring about what they do? If you create more sub-functions, it will be even better.

2. For me it would be nice to make it possible to pass a DataFrame directly to the NodesFromCSV function. At the moment I have to store the DataFrame to a csv-file and read it again. In the SolphScenario class the DataFrame has a MultiIndex but in the NodesFromCSV function you transfer the DataFrame into a different shape. @ckaldemeyer @s3pp @simnh Ii it important to be like this or do you think you could handle a DataFrame as it is read by the SolphScenario class. Otherwise I have to transform the DataFrames before calling the NodesFromCSV function.

3. We also could revise the NodesFromCSV function itself but this has not the highest priority.