### PR TITLE
Features/add graph tools

### DIFF
--- a/doc/whatsnew/v0-1-5.rst
+++ b/doc/whatsnew/v0-1-5.rst
@@ -9,6 +9,8 @@ API changes
 New features
 ############
 
+* Add an outputlib module to draw and plot energy system graphs using networx.
+
 
 Documentation
 #############

--- a/examples/solph/csv_reader/dispatch/dispatch.py
+++ b/examples/solph/csv_reader/dispatch/dispatch.py
@@ -11,6 +11,7 @@ from oemof.tools import logger
 from oemof.solph import OperationalModel, EnergySystem
 from oemof.solph import NodesFromCSV
 from oemof.outputlib import ResultsDataFrame
+from oemof.outputlib import graph_tools as gt
 
 from matplotlib import pyplot as plt
 
@@ -63,7 +64,7 @@ def run_example(config):
         'time_series': results
     }
 
-    return rdict
+    return rdict, es, om
 
 
 def plotting(results):
@@ -149,13 +150,15 @@ def run_dispatch_example(solver='cbc'):
         os.mkdir(cfg['results_path'])
 
     # run optimisation
-    my_results = run_example(config=cfg)
+    my_results, es, om = run_example(config=cfg)
 
     # plot results
     plotting(my_results)
 
-    # print(create_result_dict(my_results))
+    return es, om
 
 
 if __name__ == "__main__":
-    run_dispatch_example()
+    es, om = run_dispatch_example()
+    gt.graph(energy_system=es, optimization_model=om,
+             remove_nodes_with_substrings=['#'])

--- a/examples/solph/csv_reader/dispatch/dispatch.py
+++ b/examples/solph/csv_reader/dispatch/dispatch.py
@@ -160,5 +160,9 @@ def run_dispatch_example(solver='cbc'):
 
 if __name__ == "__main__":
     es, om = run_dispatch_example()
-    gt.graph(energy_system=es, optimization_model=om,
-             remove_nodes_with_substrings=['#'])
+
+    # create graph which could be exported into different formats
+    # https://networkx.github.io/documentation/networkx-1.10/reference/
+    # readwrite.html
+    mygraph = gt.graph(energy_system=es, optimization_model=om,
+                       remove_nodes_with_substrings=['#'])

--- a/oemof/outputlib/__init__.py
+++ b/oemof/outputlib/__init__.py
@@ -4,7 +4,7 @@
 import os
 import logging
 import pandas as pd
-import graph_tools
+from . import graph_tools
 try:
     import matplotlib.pyplot as plt
 except ImportError:

--- a/oemof/outputlib/__init__.py
+++ b/oemof/outputlib/__init__.py
@@ -4,6 +4,7 @@
 import os
 import logging
 import pandas as pd
+import graph_tools
 try:
     import matplotlib.pyplot as plt
 except ImportError:

--- a/oemof/outputlib/graph_tools.py
+++ b/oemof/outputlib/graph_tools.py
@@ -1,9 +1,16 @@
 # -*- coding: utf-8 -*-
 """Modules for creating and manipulating energy system graphs."""
 
-import pylab as plt
-import networkx as nx
-from networkx.drawing.nx_agraph import graphviz_layout
+import logging
+try:
+    import pylab as plt
+except ImportError:
+    logging.warning('Pylab could not be imported. Plotting will not work.')
+try:
+    import networkx as nx
+    from networkx.drawing.nx_agraph import graphviz_layout
+except ImportError:
+    logging.warning('Networkx could not be imported. Plotting will not work.')
 
 
 def graph(energy_system, optimization_model, edge_labels=True,
@@ -47,7 +54,6 @@ def graph(energy_system, optimization_model, edge_labels=True,
     Needs graphviz and networkx (>= v.1.11) to work properly.
     Tested on Ubuntu 16.04 x64.
     """
-
     # construct graph from nodes and flows
     G = nx.DiGraph()
     for n in energy_system.nodes:

--- a/oemof/outputlib/graph_tools.py
+++ b/oemof/outputlib/graph_tools.py
@@ -91,7 +91,7 @@ def graph(energy_system, optimization_model, edge_labels=True,
     pos = graphviz_layout(G)
     nx.draw(G, pos=pos, **options)
 
-    # add edge labels for all edges or a defined subset
+    # add edge labels for all edges
     if edge_labels is True:
         labels = nx.get_edge_attributes(G, 'weight')
         nx.draw_networkx_edge_labels(G, pos=pos, edge_labels=labels)

--- a/oemof/outputlib/graph_tools.py
+++ b/oemof/outputlib/graph_tools.py
@@ -36,6 +36,7 @@ def graph(energy_system, optimization_model, edge_labels=True,
     optimization_model : `oemof.solph.models.OperationalModel`
 
     edge_labels: Boolean
+        Use nominal values of flow as edge label
 
     remove_nodes: list of string
         Nodes to be removed e.g. ['node1', node2')]

--- a/oemof/outputlib/graph_tools.py
+++ b/oemof/outputlib/graph_tools.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+"""Modules for creating and manipulating energy system graphs."""
+
+import pylab as plt
+import networkx as nx
+from networkx.drawing.nx_agraph import graphviz_layout
+
+
+def graph(energy_system, optimization_model, edge_labels=True,
+          remove_nodes=None, remove_nodes_with_substrings=None,
+          remove_edges=None, node_color='#AFAFAF', edge_color='#CFCFCF',
+          plot=True, node_size=2000):
+    """
+    Draw a directed graph for the passed energy system.
+
+    Parameters
+    ----------
+    es : `oemof.solph.network.EnergySystem`
+
+    om : `oemof.solph.models.OperationalModel`
+
+    edge_labels: Boolean
+
+    remove_nodes: list of string
+        Nodes to be removed e.g. ['node1', node2')]
+
+    remove_nodes_with_substrings: list of substrings
+        Nodes that contain substrings to be removed e.g. ['elec_', 'heat_')]
+
+    remove_edges: list of string tuples
+        Edges to be removed e.g. [('resource_gas', 'gas_balance')]
+
+    node_color : string
+        Hex color code oder matplotlib color for node color.
+
+    edge_color
+        Hex color code oder matplotlib color for edge color.
+
+    plot : boolean
+        Show matplotlib plot.
+
+    node_size : integer
+        Size of nodes.
+
+    Notes
+    -----
+    Needs graphviz and networkx (>= v.1.11) to work properly.
+    Tested on Ubuntu 16.04 x64.
+    """
+
+    # construct graph from nodes and flows
+    G = nx.DiGraph()
+    for n in energy_system.nodes:
+        G.add_node(n.label)
+    for s, t in optimization_model.flows:
+        if optimization_model.flows[s, t].nominal_value is None:
+            G.add_edge(s.label, t.label)
+        else:
+            G.add_edge(s.label, t.label,
+                       weight=optimization_model.flows[s, t].nominal_value)
+
+    # remove nodes and edges based on precise labels
+    if remove_nodes is not None:
+        G.remove_nodes_from(remove_nodes)
+    if remove_edges is not None:
+        G.remove_edges_from(remove_edges)
+
+    # remove nodes based on substrings
+    if remove_nodes_with_substrings is not None:
+        for i in remove_nodes_with_substrings:
+            remove_nodes = [v.label for v in energy_system.nodes
+                            if i in v.label]
+            G.remove_nodes_from(remove_nodes)
+
+    # set drawing options
+    options = {
+     'prog': 'dot',
+     'with_labels': True,
+     'node_color': node_color,
+     'edge_color': edge_color,
+     'node_size': node_size
+    }
+
+    # draw graph
+    pos = graphviz_layout(G)
+    nx.draw(G, pos=pos, **options)
+
+    # add edge labels for all edges or a defined subset
+    if edge_labels is True:
+        labels = nx.get_edge_attributes(G, 'weight')
+        nx.draw_networkx_edge_labels(G, pos=pos, edge_labels=labels)
+
+    # show output
+    if plot is True:
+        plt.show()
+
+    return G

--- a/oemof/outputlib/graph_tools.py
+++ b/oemof/outputlib/graph_tools.py
@@ -3,9 +3,7 @@
 
 import logging
 import warnings
-import pandas as pd
-from oemof.solph import (Bus, Sink, LinearTransformer, Flow,
-                         OperationalModel, EnergySystem)
+
 try:
     from matplotlib import pyplot as plt
 except ImportError:
@@ -61,6 +59,9 @@ def graph(energy_system, optimization_model, edge_labels=True,
 
     Examples
     --------
+    >>> import pandas as pd
+    >>> from oemof.solph import (Bus, Sink, LinearTransformer, Flow,
+    ...                          OperationalModel, EnergySystem)
     >>> datetimeindex = pd.date_range('1/1/2017', periods=3, freq='H')
     >>> es = EnergySystem(timeindex=datetimeindex)
     >>> b_gas = Bus(label='b_gas', balanced=False)

--- a/oemof/outputlib/graph_tools.py
+++ b/oemof/outputlib/graph_tools.py
@@ -35,10 +35,10 @@ def graph(energy_system, optimization_model, edge_labels=True,
 
     optimization_model : `oemof.solph.models.OperationalModel`
 
-    edge_labels: Boolean
+    edge_labels: boolean
         Use nominal values of flow as edge label
 
-    remove_nodes: list of string
+    remove_nodes: list of strings
         Nodes to be removed e.g. ['node1', node2')]
 
     remove_nodes_with_substrings: list of strings
@@ -50,7 +50,7 @@ def graph(energy_system, optimization_model, edge_labels=True,
     node_color : string
         Hex color code oder matplotlib color for node color.
 
-    edge_color
+    edge_color : string
         Hex color code oder matplotlib color for edge color.
 
     plot : boolean

--- a/oemof/outputlib/graph_tools.py
+++ b/oemof/outputlib/graph_tools.py
@@ -7,7 +7,6 @@ import warnings
 try:
     from matplotlib import pyplot as plt
 except ImportError:
-    plt = None
     logging.warning('Matplotlib could not be imported.',
                     ' Plotting will not work.')
 try:
@@ -155,10 +154,8 @@ def graph(energy_system, optimization_model=None, edge_labels=True,
             nx.draw_networkx_edge_labels(G, pos=pos, edge_labels=labels)
 
         # show output
-        if plot is True and plt is not None:
+        if plot is True:
             plt.show()
-        else:
-            logging.warning("Graph cannot be shown due to missing packages.")
 
     else:
         logging.warning("Graph cannot be drawn due to missing packages.")

--- a/oemof/outputlib/graph_tools.py
+++ b/oemof/outputlib/graph_tools.py
@@ -27,6 +27,7 @@ def graph(energy_system, optimization_model, edge_labels=True,
           plot=True, node_size=2000):
     """
     Create a `networkx.DiGraph` for the passed energy system and plot it.
+    See http://networkx.readthedocs.io/en/latest/ for more information.
 
     Parameters
     ----------
@@ -60,6 +61,7 @@ def graph(energy_system, optimization_model, edge_labels=True,
     Examples
     --------
     >>> import pandas as pd
+    >>> import networkx as nx
     >>> from oemof.solph import (Bus, Sink, LinearTransformer, Flow,
     ...                          OperationalModel, EnergySystem)
     >>> datetimeindex = pd.date_range('1/1/2017', periods=3, freq='H')
@@ -77,6 +79,9 @@ def graph(energy_system, optimization_model, edge_labels=True,
     ...                            conversion_factors={b_el: 0.5})
     >>> om = OperationalModel(es=es)
     >>> my_graph = graph(energy_system=es, optimization_model=om, plot=False)
+    >>> # export graph as .graphml for programs like Yed where it can be
+    >>> # sorted and customized. this is especially helpful for large graphs
+    >>> # nx.write_graphml(my_graph, "my_graph.graphml")
     >>> [my_graph.has_node(n)
     ...  for n in ['b_gas', 'b_el', 'pp_gas', 'demand_el']]
     [True, True, True, True]

--- a/oemof/outputlib/graph_tools.py
+++ b/oemof/outputlib/graph_tools.py
@@ -63,7 +63,7 @@ def graph(energy_system, optimization_model, edge_labels=True,
     >>> b_gas = Bus(label='b_gas', balanced=False)
     >>> b_el = Bus(label='b_el')
     >>> demand = Sink(label='demand_el', \n
-        inputs={b_el: Flow(nominal_value=85,
+        inputs={b_el: Flow(nominal_value=85, \n
         actual_value=[0.5, 0.25, 0.75], \n
         fixed=True)})
     >>> pp_gas = LinearTransformer(label='pp_gas', \n

--- a/oemof/outputlib/graph_tools.py
+++ b/oemof/outputlib/graph_tools.py
@@ -138,6 +138,8 @@ def graph(energy_system, optimization_model, edge_labels=True,
         # show output
         if plot is True and plt is not None:
             plt.show()
+        else:
+            logging.warning("Graph cannot be shown due to missing packages.")
 
     else:
         logging.warning("Graph cannot be drawn due to missing packages.")

--- a/oemof/outputlib/graph_tools.py
+++ b/oemof/outputlib/graph_tools.py
@@ -2,6 +2,7 @@
 """Modules for creating and manipulating energy system graphs."""
 
 import logging
+import re
 import warnings
 
 try:
@@ -12,9 +13,11 @@ except ImportError:
 try:
     import networkx as nx
     from networkx.drawing.nx_agraph import graphviz_layout
+    import pygraphviz
 except ImportError:
     nx = None
     graphviz_layout = None
+    pygraphviz = None
     logging.warning('Networkx could not be imported. Plotting will not work.')
 
 warnings.filterwarnings("ignore")  # deactivate matplotlib warnings in networkx
@@ -163,6 +166,12 @@ def graph(energy_system, optimization_model=None, edge_labels=True,
 
     return G
 
+
+for o in [graph]:
+    if (((nx is None) or (graphviz_layout is None) or (pygraphviz is None)) and
+        (getattr(o, "__doc__") is not None)):
+        o.__doc__ = re.sub(r"((^|\n)\s*)>>>", r"\1>>",
+                           re.sub(r"((^|\n)\s*)\.\.\.", r"\1..", o.__doc__))
 
 if __name__ == '__main__':
     import doctest

--- a/oemof/outputlib/graph_tools.py
+++ b/oemof/outputlib/graph_tools.py
@@ -65,17 +65,20 @@ def graph(energy_system, optimization_model, edge_labels=True,
     >>> es = EnergySystem(timeindex=datetimeindex)
     >>> b_gas = Bus(label='b_gas', balanced=False)
     >>> b_el = Bus(label='b_el')
-    >>> demand = Sink(label='demand_el', \n
-        inputs={b_el: Flow(nominal_value=85, \n
-        actual_value=[0.5, 0.25, 0.75], \n
-        fixed=True)})
-    >>> pp_gas = LinearTransformer(label='pp_gas', \n
-        inputs={b_gas: Flow()}, \n
-        outputs={b_el: Flow(nominal_value=41, variable_costs=40)})
+    >>> demand = Sink(label='demand_el',
+    ...               inputs = {b_el: Flow(nominal_value=85,
+    ...                         actual_value=[0.5, 0.25, 0.75],
+    ...                         fixed=True)})
+    >>> pp_gas = LinearTransformer(label='pp_gas',
+    ...                            inputs={b_gas: Flow()},
+    ...                            outputs={b_el: Flow(nominal_value=41,
+    ...                                                variable_costs=40)},
+    ...                            conversion_factors={b_el: 0.5})
     >>> om = OperationalModel(es=es)
     >>> my_graph = graph(energy_system=es, optimization_model=om, plot=False)
-    >>> print(my_graph.nodes())
-    ['demand_el', 'b_el', 'pp_gas', 'b_gas']
+    >>> [my_graph.has_node(n)
+    ...  for n in ['b_gas', 'b_el', 'pp_gas', 'demand_el']]
+    [True, True, True, True]
 
     Notes
     -----

--- a/oemof/outputlib/graph_tools.py
+++ b/oemof/outputlib/graph_tools.py
@@ -126,8 +126,10 @@ def graph(energy_system, optimization_model, edge_labels=True,
             nx.draw_networkx_edge_labels(G, pos=pos, edge_labels=labels)
 
         # show output
-        if plot is True and plt:
+        if plot is True and plt is not None:
             plt.show()
+        else:
+            logging.warning("Graph cannot be shown due to missing packages.")
 
     else:
         logging.warning("Graph cannot be drawn due to missing packages.")

--- a/oemof/outputlib/graph_tools.py
+++ b/oemof/outputlib/graph_tools.py
@@ -62,7 +62,6 @@ def graph(energy_system, optimization_model, edge_labels=True,
     Examples
     --------
     >>> import pandas as pd
-    >>> import networkx as nx
     >>> from oemof.solph import (Bus, Sink, LinearTransformer, Flow,
     ...                          OperationalModel, EnergySystem)
     >>> datetimeindex = pd.date_range('1/1/2017', periods=3, freq='H')
@@ -82,6 +81,7 @@ def graph(energy_system, optimization_model, edge_labels=True,
     >>> my_graph = graph(energy_system=es, optimization_model=om, plot=False)
     >>> # export graph as .graphml for programs like Yed where it can be
     >>> # sorted and customized. this is especially helpful for large graphs
+    >>> # import networkx as nx
     >>> # nx.write_graphml(my_graph, "my_graph.graphml")
     >>> [my_graph.has_node(n)
     ...  for n in ['b_gas', 'b_el', 'pp_gas', 'demand_el']]

--- a/oemof/outputlib/graph_tools.py
+++ b/oemof/outputlib/graph_tools.py
@@ -13,9 +13,9 @@ except ImportError:
     logging.warning('Networkx could not be imported. Plotting will not work.')
 
 
-def graph(energy_system, optimization_model, edge_labels=True,
-          remove_nodes=None, remove_nodes_with_substrings=None,
-          remove_edges=None, node_color='#AFAFAF', edge_color='#CFCFCF',
+def graph(es, om, edge_labels=True, remove_nodes=None,
+          remove_nodes_with_substrings=None, remove_edges=None,
+          node_color='#AFAFAF', edge_color='#CFCFCF',
           plot=True, node_size=2000):
     """
     Create a `networkx.DiGraph` for the passed energy system and plot it.

--- a/oemof/outputlib/graph_tools.py
+++ b/oemof/outputlib/graph_tools.py
@@ -11,7 +11,7 @@ def graph(energy_system, optimization_model, edge_labels=True,
           remove_edges=None, node_color='#AFAFAF', edge_color='#CFCFCF',
           plot=True, node_size=2000):
     """
-    Draw a directed graph for the passed energy system.
+    Create a `networkx.DiGraph` for the passed energy system and plot it.
 
     Parameters
     ----------

--- a/oemof/outputlib/graph_tools.py
+++ b/oemof/outputlib/graph_tools.py
@@ -13,18 +13,18 @@ except ImportError:
     logging.warning('Networkx could not be imported. Plotting will not work.')
 
 
-def graph(es, om, edge_labels=True, remove_nodes=None,
-          remove_nodes_with_substrings=None, remove_edges=None,
-          node_color='#AFAFAF', edge_color='#CFCFCF',
+def graph(energy_system, optimization_model, edge_labels=True,
+          remove_nodes=None, remove_nodes_with_substrings=None,
+          remove_edges=None, node_color='#AFAFAF', edge_color='#CFCFCF',
           plot=True, node_size=2000):
     """
     Create a `networkx.DiGraph` for the passed energy system and plot it.
 
     Parameters
     ----------
-    es : `oemof.solph.network.EnergySystem`
+    energy_system : `oemof.solph.network.EnergySystem`
 
-    om : `oemof.solph.models.OperationalModel`
+    optimization_model : `oemof.solph.models.OperationalModel`
 
     edge_labels: Boolean
 

--- a/oemof/outputlib/graph_tools.py
+++ b/oemof/outputlib/graph_tools.py
@@ -31,7 +31,7 @@ def graph(energy_system, optimization_model, edge_labels=True,
     remove_nodes: list of string
         Nodes to be removed e.g. ['node1', node2')]
 
-    remove_nodes_with_substrings: list of substrings
+    remove_nodes_with_substrings: list of strings
         Nodes that contain substrings to be removed e.g. ['elec_', 'heat_')]
 
     remove_edges: list of string tuples

--- a/oemof/outputlib/graph_tools.py
+++ b/oemof/outputlib/graph_tools.py
@@ -138,8 +138,6 @@ def graph(energy_system, optimization_model, edge_labels=True,
         # show output
         if plot is True and plt is not None:
             plt.show()
-        else:
-            logging.warning("Graph cannot be shown due to missing packages.")
 
     else:
         logging.warning("Graph cannot be drawn due to missing packages.")

--- a/oemof/outputlib/graph_tools.py
+++ b/oemof/outputlib/graph_tools.py
@@ -7,7 +7,7 @@ import pandas as pd
 from oemof.solph import (Bus, Sink, LinearTransformer, Flow,
                          OperationalModel, EnergySystem)
 try:
-    import matplotlib as plt
+    from matplotlib import pyplot as plt
 except ImportError:
     plt = None
     logging.warning('Matplotlib could not be imported.',

--- a/oemof/outputlib/graph_tools.py
+++ b/oemof/outputlib/graph_tools.py
@@ -62,17 +62,15 @@ def graph(energy_system, optimization_model, edge_labels=True,
     >>> es = EnergySystem(timeindex=datetimeindex)
     >>> b_gas = Bus(label='b_gas', balanced=False)
     >>> b_el = Bus(label='b_el')
-    >>> demand = Sink(label='demand_el',
-                      inputs={b_el: Flow(nominal_value=85,
-                                         actual_value=[0.5, 0.25, 0.75],
-                                         fixed=True)})
-    >>> pp_gas = LinearTransformer(label='pp_gas',
-                                   inputs={b_gas: Flow()},
-                                   outputs={b_el: Flow(nominal_value=41,
-                                                       variable_costs=40)},
-                                   conversion_factors={b_el: 0.5})
+    >>> demand = Sink(label='demand_el', \n
+        inputs={b_el: Flow(nominal_value=85,
+        actual_value=[0.5, 0.25, 0.75], \n
+        fixed=True)})
+    >>> pp_gas = LinearTransformer(label='pp_gas', \n
+        inputs={b_gas: Flow()}, \n
+        outputs={b_el: Flow(nominal_value=41, variable_costs=40)})
     >>> om = OperationalModel(es=es)
-    >>> my_graph = graph(es, om, plot=False)
+    >>> my_graph = graph(energy_system=es, optimization_model=om, plot=False)
     >>> print(my_graph.nodes())
     ['demand_el', 'b_el', 'pp_gas', 'b_gas']
 
@@ -128,6 +126,7 @@ def graph(energy_system, optimization_model, edge_labels=True,
         plt.show()
 
     return G
+
 
 if __name__ == '__main__':
     import doctest

--- a/oemof/outputlib/graph_tools.py
+++ b/oemof/outputlib/graph_tools.py
@@ -2,15 +2,22 @@
 """Modules for creating and manipulating energy system graphs."""
 
 import logging
+import warnings
+import pandas as pd
+from oemof.solph import (Bus, Sink, LinearTransformer, Flow,
+                         OperationalModel, EnergySystem)
 try:
-    import pylab as plt
+    import matplotlib as plt
 except ImportError:
-    logging.warning('Pylab could not be imported. Plotting will not work.')
+    logging.warning('Matplotlib could not be imported.',
+                    ' Plotting will not work.')
 try:
     import networkx as nx
     from networkx.drawing.nx_agraph import graphviz_layout
 except ImportError:
     logging.warning('Networkx could not be imported. Plotting will not work.')
+
+warnings.filterwarnings("ignore")  # deactivate matplotlib warnings in networkx
 
 
 def graph(energy_system, optimization_model, edge_labels=True,
@@ -48,6 +55,26 @@ def graph(energy_system, optimization_model, edge_labels=True,
 
     node_size : integer
         Size of nodes.
+
+    Examples
+    --------
+    >>> datetimeindex = pd.date_range('1/1/2017', periods=3, freq='H')
+    >>> es = EnergySystem(timeindex=datetimeindex)
+    >>> b_gas = Bus(label='b_gas', balanced=False)
+    >>> b_el = Bus(label='b_el')
+    >>> demand = Sink(label='demand_el',
+                      inputs={b_el: Flow(nominal_value=85,
+                                         actual_value=[0.5, 0.25, 0.75],
+                                         fixed=True)})
+    >>> pp_gas = LinearTransformer(label='pp_gas',
+                                   inputs={b_gas: Flow()},
+                                   outputs={b_el: Flow(nominal_value=41,
+                                                       variable_costs=40)},
+                                   conversion_factors={b_el: 0.5})
+    >>> om = OperationalModel(es=es)
+    >>> my_graph = graph(es, om, plot=False)
+    >>> print(my_graph.nodes())
+    ['demand_el', 'b_el', 'pp_gas', 'b_gas']
 
     Notes
     -----
@@ -101,3 +128,7 @@ def graph(energy_system, optimization_model, edge_labels=True,
         plt.show()
 
     return G
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()


### PR DESCRIPTION
This adds the possibility to create and plot [networkx](http://networkx.readthedocs.io/en/networkx-1.11/) graphs in [dot graphviz](http://www.graphviz.org/) layout from a given energy system and operational model.

The returned graph can be exported, changed, ...

I wasn't sure if it's located right on the core level since it needs an opt model to work properly. But this is the case for the result-df, too and so I put it in the outputlib at the moment.