### PR TITLE
Features/multiperiod

### DIFF
--- a/examples/solph/flexible_modelling/add_constraints.py
+++ b/examples/solph/flexible_modelling/add_constraints.py
@@ -74,22 +74,22 @@ def run_add_constraints_example(solver='cbc', nologg=False):
     # add the sub-model to the oemof OperationalModel instance
     om.add_component('MyBlock', myblock)
 
-    def _inflow_share_rule(m, s, e, t):
+    def _inflow_share_rule(m, s, e, a, t):
         """pyomo rule definition: Here we can use all objects from the block or
         the om object, in this case we don't need anything from the block except
          the newly defined set MYFLOWS.
         """
-        expr = (om.flow[s, e, t] >= om.flows[s, e].outflow_share[t] *
-                sum(om.flow[i, o, t] for (i, o) in om.FLOWS if o == e))
+        expr = (om.flow[s, e, a, t] >= om.flows[s, e].outflow_share[t] *
+                sum(om.flow[i, o, a, t] for (i, o) in om.FLOWS if o == e))
         return expr
 
-    myblock.inflow_share = po.Constraint(myblock.MYFLOWS, om.TIMESTEPS,
+    myblock.inflow_share = po.Constraint(myblock.MYFLOWS, om.TIMEINDEX,
                                          rule=_inflow_share_rule)
     # add emission constraint
     myblock.emission_constr = po.Constraint(expr=(
-            sum(om.flow[i, o, t]
+            sum(om.flow[i, o, a, t]
                 for (i, o) in myblock.COMMODITYFLOWS
-                for t in om.TIMESTEPS) <= emission_limit))
+                for a, t in om.TIMEINDEX) <= emission_limit))
 
     # solve and write results to dictionary
     # you may print the model with om.pprint()

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -1247,10 +1247,10 @@ class DiscreteFlow(SimpleBlock):
         self.discrete_flow = Var(self.DISCRETE_FLOWS,
                                  m.TIMESTEPS, within=NonNegativeIntegers)
 
-        def _discrete_flow_rule(block, i, o, t):
+        def _discrete_flow_rule(block, i, o, a, t):
             """Force flow variable to discrete (NonNegativeInteger) values.
             """
-            expr = (self.discrete_flow[i, o, t] == m.flow[i, o, t])
+            expr = (self.discrete_flow[i, o, t] == m.flow[i, o, a, t])
             return expr
-        self.integer_flow = Constraint(self.DISCRETE_FLOWS, m.TIMESTEPS,
+        self.integer_flow = Constraint(self.DISCRETE_FLOWS, m.TIMEINDEX,
                                        rule=_discrete_flow_rule)

--- a/oemof/solph/models.py
+++ b/oemof/solph/models.py
@@ -110,8 +110,10 @@ class OperationalModel(po.ConcreteModel):
         self.timeincrement = kwargs.get('timeincrement',
                                         self.timeindex.freq.nanos / 3.6e12)
 
+        self.period_type = kwargs.get('period_type', 'year')
         # convert to sequence object for time dependent timeincrement
         self.timeincrement = sequence(self.timeincrement)
+
 
         if self.timesteps is None:
             raise ValueError("Missing timesteps!")
@@ -128,16 +130,19 @@ class OperationalModel(po.ConcreteModel):
         self.NODES = po.Set(initialize=[n for n in self.es.nodes])
 
         # dict helper: {'period1': 0, 'period2': 1, ...}
-        d = dict(zip(set(es.timeindex.year),
-                     range(len(set(es.timeindex.year)))))
+        periods = getattr(es.timeindex, self.period_type)
+        d = dict(zip(set(periods),range(len(set(periods)))))
+
+        # TODO: claculate period incerment based on  d
+        self.periodincrement = sequence(1)
 
         # pyomo set for timesteps of optimization problem
         self.TIMEINDEX = po.Set(
-            initialize=list(zip([d[a] for a in es.timeindex.year],
+            initialize=list(zip([d[a] for a in periods],
                                 range(len(es.timeindex)))),
                                 ordered=True)
 
-        self.PERIODS = po.Set(initialize=range(len(set(es.timeindex.year))))
+        self.PERIODS = po.Set(initialize=range(len(set(periods))))
 
         self.TIMESTEPS = po.Set(initialize=self.timesteps, ordered=True)
 

--- a/oemof/solph/models.py
+++ b/oemof/solph/models.py
@@ -122,13 +122,30 @@ class OperationalModel(po.ConcreteModel):
         # tuple of string representation of oemof nodes (source, target)
         self.flows = es.flows()
 
+
         # ###########################  SETS  ##################################
         # set with all nodes
         self.NODES = po.Set(initialize=[n for n in self.es.nodes])
 
+        # dict helper: {'period1': 0, 'period2': 1, ...}
+        d = dict(zip(set(es.timeindex.year),
+                     range(len(set(es.timeindex.year)))))
+
         # pyomo set for timesteps of optimization problem
+        self.TIMEINDEX = po.Set(
+            initialize=list(zip([d[a] for a in es.timeindex.year],
+                                range(len(es.timeindex)))),
+                                ordered=True)
+
+        self.PERIODS = po.Set(initialize=range(len(set(es.timeindex.year))))
+
         self.TIMESTEPS = po.Set(initialize=self.timesteps, ordered=True)
 
+        # TODO: Make this robust
+        self.PERIOD_TIMESTEPS = {a: range( int( len(self.TIMESTEPS) /
+                                                len(self.PERIODS) )
+                                         )
+                                 for a in self.PERIODS}
         # previous timesteps
         previous_timesteps = [x - 1 for x in self.timesteps]
         previous_timesteps[0] = self.timesteps[-1]
@@ -157,29 +174,29 @@ class OperationalModel(po.ConcreteModel):
         # ######################### FLOW VARIABLE #############################
 
         # non-negative pyomo variable for all existing flows in energysystem
-        self.flow = po.Var(self.FLOWS, self.TIMESTEPS,
+        self.flow = po.Var(self.FLOWS, self.TIMEINDEX,
                            within=po.NonNegativeReals)
 
         # loop over all flows and timesteps to set flow bounds / values
         for (o, i) in self.FLOWS:
-            for t in self.TIMESTEPS:
+            for a, t in self.TIMEINDEX:
                 if self.flows[o, i].actual_value[t] is not None and (
                         self.flows[o, i].nominal_value is not None):
                     # pre- optimized value of flow variable
-                    self.flow[o, i, t].value = (
+                    self.flow[o, i, a, t].value = (
                         self.flows[o, i].actual_value[t] *
                         self.flows[o, i].nominal_value)
                     # fix variable if flow is fixed
                     if self.flows[o, i].fixed:
-                        self.flow[o, i, t].fix()
+                        self.flow[o, i, a, t].fix()
 
                 if self.flows[o, i].nominal_value is not None and (
                         self.flows[o, i].binary is None):
                     # upper bound of flow variable
-                    self.flow[o, i, t].setub(self.flows[o, i].max[t] *
+                    self.flow[o, i, a, t].setub(self.flows[o, i].max[t] *
                                              self.flows[o, i].nominal_value)
                     # lower bound of flow variable
-                    self.flow[o, i, t].setlb(self.flows[o, i].min[t] *
+                    self.flow[o, i, a, t].setlb(self.flows[o, i].min[t] *
                                              self.flows[o, i].nominal_value)
 
         self.positive_flow_gradient = po.Var(self.POSITIVE_GRADIENT_FLOWS,
@@ -277,8 +294,8 @@ class OperationalModel(po.ConcreteModel):
         for i, o in self.flows:
 
             result[i] = result.get(i, UserDict())
-            result[i][o] = UserList([self.flow[i, o, t].value
-                                     for t in self.TIMESTEPS])
+            result[i][o] = UserList([self.flow[i, o, a, t].value
+                                     for a, t in self.TIMEINDEX])
 
             if isinstance(i, Storage):
                 if i.investment is None:
@@ -301,13 +318,14 @@ class OperationalModel(po.ConcreteModel):
         # add results of dual variables for balanced buses
         if hasattr(self, "dual"):
             # grouped = [(b1, [(b1, 0), (b1, 1)]), (b2, [(b2, 0), (b2, 1)])]
+            #import pdb; pdb.set_trace()
             grouped = groupby(sorted(self.Bus.balance.iterkeys()),
                               lambda pair: pair[0])
 
             for bus, timesteps in grouped:
                 result[bus] = result.get(bus, UserDict())
-                result[bus][bus] = [self.dual[self.Bus.balance[bus, t]]
-                                    for _, t in timesteps]
+                result[bus][bus] = [self.dual[self.Bus.balance[bus, a, t]]
+                                    for _, a, t in timesteps]
 
         result.investment = investment
 

--- a/oemof/solph/network.py
+++ b/oemof/solph/network.py
@@ -134,8 +134,8 @@ class Flow:
         self.negative_gradient = sequence(kwargs.get('negative_gradient'))
         self.variable_costs = sequence(kwargs.get('variable_costs'))
         self.fixed_costs = kwargs.get('fixed_costs')
-        self.summed_max = kwargs.get('summed_max')
-        self.summed_min = kwargs.get('summed_min')
+        self.summed_max = sequence(kwargs.get('summed_max'))
+        self.summed_min = sequence(kwargs.get('summed_min'))
         self.fixed = kwargs.get('fixed', False)
         self.investment = kwargs.get('investment')
         if self.fixed and self.actual_value is None:


### PR DESCRIPTION
I do need a new functionality and I would like to integrate that in oemof solph. The basic idea here is the following; 

Change the timeindex for t=[0, 1, 2, etc...] to (a,t) = [(0, 1), (0, 2) .., (1, 5)...]. We will keep timesteps, so if there are two years to be calculated timesteps would be 0...8760*2 other index sets will be: 

* TIMEINDEX: (a,t) 
* PERIODS:  
* PERIOD_TIMESTEPS: the sliced timesteps for each period e.g. for a=0 -> 0...8769, for a=1 -> 8760-> 8760*2 -1

As there will still be the TIMESTEP index the results etc will not be affected. So everything works as it has before. 

There is one new functionality: summed_may/min per period (Of course the does not need to be a year, we can keep it more flexible e.g month...)

Tests work, bu lp-files are broken of course...

This pull request should only change the index to allow further development.
We can start of with this minimal solution and add extra functionality (s. below) based on this, e.g. get specific period bounds on storages, look how we use the investment for this (investment per period or the complete timesteps)

TODO: 

* [ ] Update constraints documentations 

For the future: 
* [ ] Add discount per period to the objective expressions? (decide where to put that, I assume best would be in the energysystem 
* [ ]  Allow to do investment per period (consider lifetime in Investment object, max invest rate, init lifetime etc) 
* [ ] Add periodincrement 

