### PR TITLE
Add hints to the start page (documentation)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,7 @@ Documentation
 =============
 
 Full documentation can be found at `readthedocs <http://oemof.readthedocs.org>`_. Use the `project site <http://readthedocs.org/projects/oemof>`_ of readthedocs to choose the version of the documentation. To get the latest news visit and follow our `website <https://www.oemof.org>`_.
+Go to the `download page <http://readthedocs.org/projects/oemof/downloads/>`_ to download different versions and formats (pdf, html, epup) of the documentation.
 
 
 Installing oemof

--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,12 @@ Keep in touch
 You can become a watcher at our `github site <https://github.com/oemof/oemof>`_, but this will bring you quite a few mails and might be more interesting for developers. If you just want to get the latest news you can follow our news-blog at `oemof.org <https://oemof.org/>`_.
 
 
+Citing oemof
+============
+
+We use the zenodo project to get a DOI for each version. `Search zenodo for the right citation of your oemof version <https://zenodo.org/search?page=1&size=20&q=oemof>`_.
+
+
 License
 =======
 

--- a/README.rst
+++ b/README.rst
@@ -13,9 +13,9 @@ Everybody is welcome to use and/or develop oemof. Read our `'Why should I contri
 Documentation
 =============
 
-Full documentation can be found at `readthedocs <http://oemof.readthedocs.org>`_. Use the `project site <http://readthedocs.org/projects/oemof>`_ of readthedocs to choose the version of the documentation. To get the latest news visit and follow our `website <https://www.oemof.org>`_.
-Go to the `download page <http://readthedocs.org/projects/oemof/downloads/>`_ to download different versions and formats (pdf, html, epup) of the documentation.
+Full documentation can be found at `readthedocs <http://oemof.readthedocs.org>`_. Use the `project site <http://readthedocs.org/projects/oemof>`_ of readthedocs to choose the version of the documentation. Go to the `download page <http://readthedocs.org/projects/oemof/downloads/>`_ to download different versions and formats (pdf, html, epup) of the documentation.
 
+To get the latest news visit and follow our `website <https://www.oemof.org>`_.
 
 Installing oemof
 ================

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Everybody is welcome to use and/or develop oemof. Read our `'Why should I contri
 Documentation
 =============
 
-Full documentation can be found at `readthedocs <http://oemof.readthedocs.org>`_. Use the `project site <http://readthedocs.org/projects/oemof>`_ of readthedocs to choose the version of the documentation. Go to the `download page <http://readthedocs.org/projects/oemof/downloads/>`_ to download different versions and formats (pdf, html, epup) of the documentation.
+Full documentation can be found at `readthedocs <http://oemof.readthedocs.org>`_. Use the `project site <http://readthedocs.org/projects/oemof>`_ of readthedocs to choose the version of the documentation. Go to the `download page <http://readthedocs.org/projects/oemof/downloads/>`_ to download different versions and formats (pdf, html, epub) of the documentation.
 
 To get the latest news visit and follow our `website <https://www.oemof.org>`_.
 

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -61,6 +61,12 @@ Keep in touch
 You can become a watcher at our `github site <https://github.com/oemof/oemof>`_, but this will bring you quite a few mails and might be more interesting for developers. If you just want to get the latest news you can follow our news-blog at `oemof.org <https://oemof.org/>`_.
 
 
+Citing oemof
+============
+
+We use the zenodo project to get a DOI for each version. `Search zenodo for the right citation of your oemof version <https://zenodo.org/search?page=1&size=20&q=oemof>`_.
+
+
 License
 =======
 

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -17,8 +17,9 @@ Everybody is welcome to use and/or develop oemof. Read our :ref:`why_contribute_
 Documentation
 =============
 
-Full documentation can be found at `readthedocs <http://oemof.readthedocs.org>`_. Use the `project site <http://readthedocs.org/projects/oemof>`_ of readthedocs to choose the version of the documentation. To get the latest news visit and follow our `website <https://www.oemof.org>`_.
-Go to the `download page <http://readthedocs.org/projects/oemof/downloads/>`_ to download different versions and formats (pdf, html, epup) of the documentation.
+Full documentation can be found at `readthedocs <http://oemof.readthedocs.org>`_. Use the `project site <http://readthedocs.org/projects/oemof>`_ of readthedocs to choose the version of the documentation. Go to the `download page <http://readthedocs.org/projects/oemof/downloads/>`_ to download different versions and formats (pdf, html, epup) of the documentation.
+
+To get the latest news visit and follow our `website <https://www.oemof.org>`_.
 
 
 Installing oemof

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -17,7 +17,7 @@ Everybody is welcome to use and/or develop oemof. Read our :ref:`why_contribute_
 Documentation
 =============
 
-Full documentation can be found at `readthedocs <http://oemof.readthedocs.org>`_. Use the `project site <http://readthedocs.org/projects/oemof>`_ of readthedocs to choose the version of the documentation. Go to the `download page <http://readthedocs.org/projects/oemof/downloads/>`_ to download different versions and formats (pdf, html, epup) of the documentation.
+Full documentation can be found at `readthedocs <http://oemof.readthedocs.org>`_. Use the `project site <http://readthedocs.org/projects/oemof>`_ of readthedocs to choose the version of the documentation. Go to the `download page <http://readthedocs.org/projects/oemof/downloads/>`_ to download different versions and formats (pdf, html, epub) of the documentation.
 
 To get the latest news visit and follow our `website <https://www.oemof.org>`_.
 

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -18,6 +18,7 @@ Documentation
 =============
 
 Full documentation can be found at `readthedocs <http://oemof.readthedocs.org>`_. Use the `project site <http://readthedocs.org/projects/oemof>`_ of readthedocs to choose the version of the documentation. To get the latest news visit and follow our `website <https://www.oemof.org>`_.
+Go to the `download page <http://readthedocs.org/projects/oemof/downloads/>`_ to download different versions and formats (pdf, html, epup) of the documentation.
 
 
 Installing oemof


### PR DESCRIPTION
* add a hint how to cite oemof according to a question on the user meeting
* add a hint how to download the documentation according to PR #314