### PR TITLE
Remove datetimeindex from OperationalModel

### DIFF
--- a/oemof/energy_system.py
+++ b/oemof/energy_system.py
@@ -8,6 +8,7 @@ Created on Mon Jul 20 15:53:14 2015
 from functools import partial
 import logging
 import os
+import pandas as pd
 
 import dill as pickle
 
@@ -30,10 +31,8 @@ class EnergySystem:
         <oemof.core.network.Entity>` that should be part of the energy system.
         Stored in the :attr:`entities` attribute.
         Defaults to `[]` if not supplied.
-    timeindex : pandas.index, optional
-        Define the time range and increment for the energy system. This is an
-        optional parameter but might be import for other functions/methods that
-        use the EnergySystem class as an input parameter.
+    timeindex : pandas.datetimeindex
+        Define the time range and increment for the energy system.
     groupings : list
         The elements of this list are used to construct :class:`Groupings
         <oemof.core.energy_system.Grouping>` or they are used directly if they
@@ -116,7 +115,9 @@ class EnergySystem:
             for g in self._groupings:
                 g(e, self.groups)
         self.results = kwargs.get('results')
-        self.timeindex = kwargs.get('timeindex')
+        self.timeindex = kwargs.get('timeindex',
+                                    pd.date_range(start=pd.to_datetime('today'),
+                                                  periods=1, freq='H'))
 
     @staticmethod
     def _regroup(entity, groups, groupings):

--- a/oemof/solph/models.py
+++ b/oemof/solph/models.py
@@ -32,20 +32,6 @@ class OperationalModel(po.ConcreteModel):
         Solph looks for these groups in the given energy system and uses them
         to create the constraints of the optimization problem.
         Defaults to :const:`OperationalModel.CONSTRAINTS`
-    timeindex : pandas DatetimeIndex
-        The time index will be used to calculate the timesteps and the
-        time increment for the optimization model.
-    timesteps : sequence (optional)
-        Timesteps used in the optimization model. If provided as list or
-        pandas.DatetimeIndex the sequence will be used to index the time
-        dependent variables, constraints etc. If not provided we will try to
-        compute this sequence from attr:`timeindex`.
-    timeincrement : float or list of floats (optional)
-        Time increment used in constraints and objective expressions.
-        If type is 'float', will be converted internally to
-        solph.plumbing.Sequence() object for time dependent time increment.
-        If a list is provided this list will be taken. Default is calculated
-        from timeindex if provided.
 
     **The following sets are created**:
 
@@ -96,16 +82,10 @@ class OperationalModel(po.ConcreteModel):
 
         self.name = kwargs.get('name', 'OperationalModel')
         self.es = es
-        self.timeindex = kwargs.get('timeindex', es.timeindex)
-        self.timesteps = kwargs.get('timesteps', range(len(self.timeindex)))
-        self.timeincrement = kwargs.get('timeincrement',
-                                        self.timeindex.freq.nanos / 3.6e12)
+        self.timeindex = es.timeindex
+        self.timesteps = range(len(self.timeindex))
+        self.timeincrement = sequence(self.timeindex.freq.nanos / 3.6e12)
 
-        # convert to sequence object for time dependent timeincrement
-        self.timeincrement = sequence(self.timeincrement)
-
-        if self.timesteps is None:
-            raise ValueError("Missing timesteps!")
         self._constraint_groups = (OperationalModel.CONSTRAINT_GROUPS +
                                    kwargs.get('constraint_groups', []))
 


### PR DESCRIPTION
I looked at the examples and at the documentation and we only use the datetimeindex inside the EnergySystem so I like to remove it from OM