### PR TITLE
changing simple_dispatch with simple_dispatch

### DIFF
--- a/doc/installation_and_setup.rst
+++ b/doc/installation_and_setup.rst
@@ -248,7 +248,7 @@ Execute an example with different solver (default: 'cbc').
 
 .. code:: console
 
-  oemof_examples simple_least_costs
-  oemof_examples simple_least_costs -s glpk
+  oemof_examples simple_dispatch
+  oemof_examples simple_dispatch -s glpk
 
 If you want to run solph examples you need to have a solver installed (recommended: cbc), see the ":ref:`linux_solver_label`" or ":ref:`windows_solver_label`" section. To get more information about the solph examples see the ":ref:`solph_examples_label`" section.


### PR DESCRIPTION
The simple_least_costs example is not executable in the last oemof version, so I suggest to change it to  simple_dispatch or similar.