### PR TITLE
rename VariableFractionTurbine and its attribute

### DIFF
--- a/doc/oemof_solph.rst
+++ b/doc/oemof_solph.rst
@@ -223,14 +223,14 @@ If the low-temperature reservoir is nearly infinite (ambient air heat pump) the 
 
 .. note:: See the :py:class:`~oemof.solph.network.Transformer` class for all parameters and the mathematical background.
 
-VariableFractionTransformer
+ExtractionTurbineCHP
 +++++++++++++++++++++++++++
 
-The VariableFractionTransformer inherits from the :ref:`transformer_class_label` class. An instance of this class can represent a component with one input and two output flows and a flexible ratio between these flows. By now this class is restricted to one input and two output flows. One application example would be a flexible combined heat and power (chp) plant. The class allows to define a different efficiency for every time step but this series has to be predefined as a parameter for the optimisation. In contrast to the LinearTransformer, a main flow and a tapped flow is defined. For the main flow you can define a conversion factor if the second flow is zero (conversion_factor_single_flow).
+The ExtractionTurbineCHP inherits from the :ref:`transformer_class_label` class. An instance of this class can represent a component with one input and two output flows and a flexible ratio between these flows. By now this class is restricted to one input and two output flows. One application example would be a flexible combined heat and power (chp) plant. The class allows to define a different efficiency for every time step but this series has to be predefined as a parameter for the optimisation. In contrast to the LinearTransformer, a main flow and a tapped flow is defined. For the main flow you can define a conversion factor if the second flow is zero (conversion_factor_single_flow).
 
 .. code-block:: python
 
-    solph.VariableFractionTransformer(
+    solph.ExtractionTurbineCHP(
         label='variable_chp_gas',
         inputs={b_gas: solph.Flow(nominal_value=10e10)},
         outputs={b_el: solph.Flow(), b_th: solph.Flow()},
@@ -245,7 +245,7 @@ The key of the parameter *'conversion_factor_single_flow'* will indicate the mai
    :alt: variable_chp_plot.svg
    :align: center
 
-.. note:: See the :py:class:`~oemof.solph.components.VariableFractionTransformer` class for all parameters and the mathematical background.
+.. note:: See the :py:class:`~oemof.solph.components.ExtractionTurbineCHP` class for all parameters and the mathematical background.
 
 Storage
 +++++++

--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -808,17 +808,14 @@ class GenericCHPBlock(SimpleBlock):
 
 class ExtractionTurbineCHP(Transformer):
     r"""
-    Component `GenericCHP` to model combined heat and power plants.
-
-    A linear transformer with more than one output, where the fraction of
-    the output flows is variable. By now it is restricted to two output flows.
+    A CHP with an extraction turbine in a linear model. For more options see
+    the :class:`~oemof.solph.components.GenericCHP` class.
 
     One main output flow has to be defined and is tapped by the remaining flow.
-    Thus, the main output will be reduced if the tapped output increases.
-    Therefore a loss index has to be defined. Furthermore a maximum efficiency
-    has to be specified if the whole flow is led to the main output
-    (tapped_output = 0). The state with the maximum tapped_output is described
-    through conversion factors equivalent to the LinearTransformer.
+    The conversion factors have to be defined for the maximum tapped flow (
+    full CHP mode) and for no tapped flow (full condensing mode). Even though it
+    is possible to limit the variability of the tapped flow, so that the full
+    condensing mode will never be reached.
 
     Parameters
     ----------
@@ -827,7 +824,7 @@ class ExtractionTurbineCHP(Transformer):
         to specified outflow. Keys are output bus objects.
         The dictionary values can either be a scalar or a sequence with length
         of time horizon for simulation.
-    conversion_factor_single_flow : dict
+    conversion_factor_full_condensation : dict
         The efficiency of the main flow if there is no tapped flow. Only one
         key is allowed. Use one of the keys of the conversion factors. The key
         indicates the main flow. The other output flow is the tapped flow.
@@ -868,14 +865,14 @@ class ExtractionTurbineCHP(Transformer):
 
 class ExtractionTurbineCHPBlock(SimpleBlock):
     r"""Block for the linear relation of nodes with type
-    :class:`~oemof.solph.network.ExtractionTurbineCHP`
+    :class:`~oemof.solph.components.ExtractionTurbineCHP`
 
     **The following sets are created:** (-> see basic sets at
     :class:`.Model` )
 
     VARIABLE_FRACTION_TRANSFORMERS
         A set with all
-        :class:`~oemof.solph.network.ExtractionTurbineCHP` objects.
+        :class:`~oemof.solph.components.ExtractionTurbineCHP` objects.
 
     **The following constraints are created:**
 

--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -285,12 +285,12 @@ class Constraint_Tests:
         bth = solph.Bus(label='heatBus')
         bgas = solph.Bus(label='commodityBus')
 
-        solph.components.VariableFractionTransformer(
+        solph.components.ExtractionTurbineCHP(
             label='variable_chp_gas',
             inputs={bgas: solph.Flow(nominal_value=100)},
             outputs={bel: solph.Flow(), bth: solph.Flow()},
             conversion_factors={bel: 0.3, bth: 0.5},
-            conversion_factor_single_flow={bel: 0.5})
+            conversion_factor_full_condensation={bel: 0.5})
 
         self.compare_lp_files('variable_chp.lp')
 

--- a/tests/lp_files/variable_chp.lp
+++ b/tests/lp_files/variable_chp.lp
@@ -42,35 +42,35 @@ c_e_Bus_balance(heatBus_2)_:
 +1 flow(variable_chp_gas_heatBus_2)
 = 0
 
-c_e_VariableFractionTransformerBlock_input_output_relation(variable_chp_gas_0)_:
+c_e_ExtractionTurbineCHPBlock_input_output_relation(variable_chp_gas_0)_:
 +1 flow(commodityBus_variable_chp_gas_0)
 -2 flow(variable_chp_gas_electricityBus_0)
 -0.80000000000000004 flow(variable_chp_gas_heatBus_0)
 = 0
 
-c_e_VariableFractionTransformerBlock_input_output_relation(variable_chp_gas_1)_:
+c_e_ExtractionTurbineCHPBlock_input_output_relation(variable_chp_gas_1)_:
 +1 flow(commodityBus_variable_chp_gas_1)
 -2 flow(variable_chp_gas_electricityBus_1)
 -0.80000000000000004 flow(variable_chp_gas_heatBus_1)
 = 0
 
-c_e_VariableFractionTransformerBlock_input_output_relation(variable_chp_gas_2)_:
+c_e_ExtractionTurbineCHPBlock_input_output_relation(variable_chp_gas_2)_:
 +1 flow(commodityBus_variable_chp_gas_2)
 -2 flow(variable_chp_gas_electricityBus_2)
 -0.80000000000000004 flow(variable_chp_gas_heatBus_2)
 = 0
 
-c_u_VariableFractionTransformerBlock_out_flow_relation(variable_chp_gas_0)_:
+c_u_ExtractionTurbineCHPBlock_out_flow_relation(variable_chp_gas_0)_:
 -1 flow(variable_chp_gas_electricityBus_0)
 +0.59999999999999998 flow(variable_chp_gas_heatBus_0)
 <= 0
 
-c_u_VariableFractionTransformerBlock_out_flow_relation(variable_chp_gas_1)_:
+c_u_ExtractionTurbineCHPBlock_out_flow_relation(variable_chp_gas_1)_:
 -1 flow(variable_chp_gas_electricityBus_1)
 +0.59999999999999998 flow(variable_chp_gas_heatBus_1)
 <= 0
 
-c_u_VariableFractionTransformerBlock_out_flow_relation(variable_chp_gas_2)_:
+c_u_ExtractionTurbineCHPBlock_out_flow_relation(variable_chp_gas_2)_:
 -1 flow(variable_chp_gas_electricityBus_2)
 +0.59999999999999998 flow(variable_chp_gas_heatBus_2)
 <= 0

--- a/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
+++ b/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
@@ -20,7 +20,6 @@ chp plant produces heat and power excess and therefore needs more natural gas.
 from oemof import outputlib
 
 # Default logger of oemof
-from oemof.tools import logger
 import oemof.solph as solph
 
 # import oemof base classes to create energy system objects

--- a/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
+++ b/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
@@ -84,12 +84,12 @@ def test_variable_chp(filename="variable_chp.csv", solver='cbc'):
         conversion_factors={bel2: 0.3, bth2: 0.5})
 
     # create a fixed transformer to distribute to the heat and elec buses
-    solph.components.VariableFractionTransformer(
+    solph.components.ExtractionTurbineCHP(
         label='variable_chp_gas',
         inputs={bgas: solph.Flow(nominal_value=10e10)},
         outputs={bel: solph.Flow(), bth: solph.Flow()},
         conversion_factors={bel: 0.3, bth: 0.5},
-        conversion_factor_single_flow={bel: 0.5}
+        conversion_factor_full_condensation={bel: 0.5}
         )
 
     ##########################################################################


### PR DESCRIPTION
I renamed the `VariableFractionTurbine` turbine to `ExtractionTurbineCHP` and the attribute from `conversion_factor_single_flow` to `conversion_factor_full_condensation`.

Any objections?

See: #361.