### PR TITLE
Features/node flows

### DIFF
--- a/oemof/outputlib/views.py
+++ b/oemof/outputlib/views.py
@@ -118,3 +118,18 @@ def filter_nodes(results, option=NodeOption.All, exclude_busses=False):
         return {n for n in nodes if not isinstance(n, Bus)}
     else:
         return nodes
+
+
+def get_node_by_name(results, *names):
+    """
+    Searches results for nodes
+
+    Names are looked up in nodes from results and either returned single node
+    (in case only one name is given) or as list of nodes. If name is not found,
+    None is returned.
+    """
+    nodes = filter_nodes(results)
+    if len(names) == 1:
+        return next(filter(lambda x: str(x) == names[0], nodes), None)
+    else:
+        return [n if str(n) in names else None for n in nodes]

--- a/oemof/outputlib/views.py
+++ b/oemof/outputlib/views.py
@@ -5,7 +5,11 @@ Modules for providing convenient views for solph results.
 Information about the possible usage is provided within the examples.
 """
 
+from enum import Enum
+from itertools import zip_longest
 import pandas as pd
+
+from oemof.network import Bus
 
 
 def convert_keys_to_strings(results):
@@ -65,3 +69,52 @@ def node(results, node):
         filtered['sequences'].sort_index(axis=1, inplace=True)
 
     return filtered
+
+
+class NodeOption(Enum):
+    All = 0
+    HasOutputs = 1
+    HasInputs = 2
+    HasOnlyOutputs = 3
+    HasOnlyInputs = 4
+
+
+def get_nodes(results, option=NodeOption.All, exclude_busses=False):
+    """
+    Get set of nodes from results-dict for given node option
+
+    See NodeOption for all options. This function filters nodes from results
+    for special needs.
+
+    Parameters
+    ----------
+    results: dict
+    option: NodeOption
+    exclude_busses: bool
+        If set all bus nodes are excluded from resulting node set
+
+    Returns
+    -------
+    :obj:'set' of Node
+    """
+    node_from, node_to = map(
+        lambda x: set(x) - {None},
+        zip_longest(*list(results))
+    )
+    if option == NodeOption.All:
+        nodes = node_from.union(node_to)
+    elif option == NodeOption.HasOutputs:
+        nodes = node_from
+    elif option == NodeOption.HasInputs:
+        nodes = node_to
+    elif option == NodeOption.HasOnlyOutputs:
+        nodes = node_from - node_to
+    elif option == NodeOption.HasOnlyInputs:
+        nodes = node_to - node_from
+    else:
+        raise ValueError('Invalid node option "' + str(option) + '"')
+
+    if exclude_busses:
+        return {n for n in nodes if not isinstance(n, Bus)}
+    else:
+        return nodes

--- a/oemof/outputlib/views.py
+++ b/oemof/outputlib/views.py
@@ -177,7 +177,7 @@ def __get_flow_component(nodes, current_node):
     of result is returned.
     """
     if nodes[1] is None:
-        return NodeFlow(nodes, FlowType.Single)
+        return NodeFlow(nodes[0], FlowType.Single)
     elif nodes[0] == current_node:
         return NodeFlow(current_node.outputs[nodes[1]], FlowType.Output)
     else:

--- a/oemof/outputlib/views.py
+++ b/oemof/outputlib/views.py
@@ -79,7 +79,7 @@ class NodeOption(Enum):
     HasOnlyInputs = 4
 
 
-def get_nodes(results, option=NodeOption.All, exclude_busses=False):
+def filter_nodes(results, option=NodeOption.All, exclude_busses=False):
     """
     Get set of nodes from results-dict for given node option
 

--- a/oemof/tools/logger.py
+++ b/oemof/tools/logger.py
@@ -18,8 +18,6 @@ def define_logging(logpath=None, logfile='oemof.log', file_format=None,
     ----------
     logfile : str
         Name of the log file, default: oemof.log
-    text : str
-        Header text to separate the logging blocks within the output file.
     logpath : str
         The path for log files. By default a ".oemof' folder is created in your
         home directory with subfolder called 'log_files'.
@@ -68,7 +66,6 @@ def define_logging(logpath=None, logfile='oemof.log', file_format=None,
     17:56:51-INFO-Path for logging: /HOME/.oemof/log_files
     ...
     >>> logging.debug("Hallo")
-
     """
 
     if logpath is None:

--- a/tests/result_tests.py
+++ b/tests/result_tests.py
@@ -1,0 +1,157 @@
+
+from nose.tools import ok_, eq_
+import pandas
+from oemof.solph import (
+    EnergySystem, Bus, Transformer, Flow, Investment, Sink, Model)
+from oemof.solph.components import GenericStorage
+from oemof.outputlib import processing, views
+
+
+class Flow_Tests:
+    @classmethod
+    def setUpClass(cls):
+        cls.period = 24
+        cls.es = EnergySystem(
+            timeindex=pandas.date_range(
+                '2016-01-01',
+                periods=cls.period,
+                freq='H'
+            )
+        )
+
+        # BUSSES
+        b_el1 = Bus(label="b_el1")
+        b_el2 = Bus(label="b_el2")
+        b_diesel = Bus(label='b_diesel', balanced=False)
+        cls.es.add(b_el1, b_el2, b_diesel)
+
+        # TEST DIESEL:
+        dg = Transformer(
+            label='diesel',
+            inputs={b_diesel: Flow(variable_costs=2)},
+            outputs={
+                b_el1: Flow(
+                    variable_costs=1,
+                    fixed_costs=20,
+                    investment=Investment(ep_costs=0.5)
+                )
+            },
+            conversion_factors={b_el1: 2},
+        )
+
+        batt = GenericStorage(
+            label='storage',
+            inputs={b_el1: Flow(variable_costs=3)},
+            outputs={b_el2: Flow(variable_costs=2.5)},
+            capacity_loss=0.00,
+            initial_capacity=0,
+            nominal_input_capacity_ratio=1 / 6,
+            nominal_output_capacity_ratio=1 / 6,
+            inflow_conversion_factor=1,
+            outflow_conversion_factor=0.8,
+            fixed_costs=35,
+            investment=Investment(ep_costs=0.4),
+        )
+
+        demand = [100] * 8760
+        demand[0] = 0.0
+        demand = Sink(
+            label="demand_el",
+            inputs={
+                b_el2: Flow(
+                    nominal_value=1,
+                    actual_value=demand,
+                    fixed=True
+                )
+            }
+        )
+        cls.es.add(dg, batt, demand)
+        om = Model(cls.es)
+        om.solve(solver='cbc')
+        cls.results = processing.results(om)
+
+    def test_filter_nodes(self):
+        nodes = views.filter_nodes(self.results)
+        eq_(len(nodes), 6)
+        nodes = views.filter_nodes(self.results, exclude_busses=True)
+        eq_(len(nodes), 3)
+        nodes = views.filter_nodes(
+            self.results,
+            option=views.NodeOption.HasInputs
+        )
+        eq_(len(nodes), 5)
+        nodes = views.filter_nodes(
+            self.results,
+            option=views.NodeOption.HasInputs,
+            exclude_busses=True
+        )
+        eq_(len(nodes), 3)
+        nodes = views.filter_nodes(
+            self.results,
+            option=views.NodeOption.HasOutputs
+        )
+        eq_(len(nodes), 5)
+        nodes = views.filter_nodes(
+            self.results,
+            option=views.NodeOption.HasOnlyInputs
+        )
+        eq_(len(nodes), 1)
+        nodes = views.filter_nodes(
+            self.results,
+            option=views.NodeOption.HasOnlyOutputs
+        )
+        eq_(len(nodes), 1)
+        nodes = views.filter_nodes(
+            self.results,
+            option=views.NodeOption.HasOnlyOutputs,
+            exclude_busses=True
+        )
+        eq_(len(nodes), 0)
+
+    def test_get_node_by_name(self):
+        b_diesel = views.get_node_by_name(self.results, 'b_diesel')
+        eq_(b_diesel, self.es.groups['b_diesel'])
+        dg, storage = views.get_node_by_name(
+            self.results,
+            'diesel',
+            'storage'
+        )
+        eq_(dg, self.es.groups['diesel'])
+        eq_(storage, self.es.groups['storage'])
+
+    def test_input_flows(self):
+        dg = self.es.groups['diesel']
+        input_flows = views.flows(
+            self.results,
+            dg,
+            flow_type=views.FlowType.Input
+        )
+        eq_(len(input_flows), 1)
+
+        b_diesel = self.es.groups['b_diesel']
+        ok_(isinstance(input_flows[(b_diesel, dg)], Flow))
+
+    def test_node_with_flows(self):
+        storage = self.es.groups['storage']
+        node_results = views.node(self.results, storage, get_flows=True)
+        ok_('flows' in node_results)
+        eq_(len(node_results['flows']), 3)
+
+        b_el1 = self.es.groups['b_el1']
+        b_el2 = self.es.groups['b_el2']
+        flow = node_results['flows'][(b_el1, storage)]
+        eq_(flow.type, views.FlowType.Input)
+        eq_(flow.component.variable_costs, [3] * self.period)
+        # Test other flow type comparison:
+        eq_(
+            node_results['flows'][(b_el1, storage)].type,
+            'input'
+        )
+        eq_(
+            node_results['flows'][(storage, b_el2)].type,
+            views.FlowType.Output
+        )
+        eq_(
+            node_results['flows'][(storage, None)].type,
+            views.FlowType.Single
+        )


### PR DESCRIPTION
Hi everyone,

I talked to @uvchik today and we discussed how to add the Flow components to node results.
As I worked on that lately, I added my solution here.
Now, if `get_flows` is set to `True` in `node` function, flows are added as new dictionary containing the  tuple `((from_node, to_node), flow_name)` from `sequences` columns as keys and a namedtuple containing `Flow` and `FlowType` as values.
Here is an example how to get all input Flows of a storage node:
```
storage_results = views.node(results, storage, get_flows=True)
print(
    list(
        nodes for (nodes, flow_name), flow in
        storage_results['flows'].items()
        if flow.type == 'input'
    )
)
```

Additionally I added two functions I often need to filter nodes from results or to get node via label.

Are you fine with this approach? Please give me feedback on this!