### PR TITLE
Make it possible to define the nominal_value of flows directly in the storage definition

### DIFF
--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -9,8 +9,8 @@ from pyomo.core.base.block import SimpleBlock
 from pyomo.environ import (Binary, Set, NonNegativeReals, Var, Constraint,
                            Expression, BuildAction)
 import numpy as np
-import warnings
-from oemof.network import Bus, Transformer
+
+from oemof.network import Bus
 from oemof.solph import Flow, Transformer
 from .options import Investment
 from .plumbing import sequence
@@ -28,13 +28,15 @@ class GenericStorage(Transformer):
     ----------
     nominal_capacity : numeric
         Absolute nominal capacity of the storage
-    nominal_input_capacity_ratio :  numeric
-        Ratio between the nominal inflow of the storage and its capacity.
     nominal_output_capacity_ratio : numeric
-        Ratio between the nominal outflow of the storage and its capacity.
+        Ratio between the nominal outflow of the storage and its capacity. For
+        batteries this is also know as c-rate.
         Note: This ratio is used to create the Flow object for the outflow
-        and set its nominal value of the storage in the constructor.
+        and set its nominal value of the storage in the constructor. If no
+        investment object is defined it is also possible to set the nominal
+        value of the flow directly in its constructor.
     nominal_input_capacity_ratio : numeric
+        Ratio between the nominal inflow of the storage and its capacity.
         see: nominal_output_capacity_ratio
     initial_capacity : numeric
         The capacity of the storage in the first (and last) time step of
@@ -73,9 +75,9 @@ class GenericStorage(Transformer):
         super().__init__(*args, **kwargs)
         self.nominal_capacity = kwargs.get('nominal_capacity')
         self.nominal_input_capacity_ratio = kwargs.get(
-            'nominal_input_capacity_ratio', 0.2)
+            'nominal_input_capacity_ratio', None)
         self.nominal_output_capacity_ratio = kwargs.get(
-            'nominal_output_capacity_ratio', 0.2)
+            'nominal_output_capacity_ratio', None)
         self.initial_capacity = kwargs.get('initial_capacity')
         self.capacity_loss = sequence(kwargs.get('capacity_loss', 0))
         self.inflow_conversion_factor = sequence(
@@ -88,44 +90,29 @@ class GenericStorage(Transformer):
         self.capacity_min = sequence(kwargs.get('capacity_min', 0))
         self.fixed_costs = kwargs.get('fixed_costs')
         self.investment = kwargs.get('investment')
+
         # Check investment
+        msg_no_nv = ("No nominal value allowed with investment object."
+                     "(DRAFT!) {0}")
         if self.investment and self.nominal_capacity is not None:
-            self.nominal_capacity = None
-            warnings.warn(
-                "Using the investment object the nominal_capacity is set to" +
-                "None.", SyntaxWarning)
-        # Check input flows for nominal value
-        for flow in self.inputs.values():
-            if flow.nominal_value is not None:
-                storage_nominal_value_warning('output')
-            if self.nominal_capacity is None:
-                flow.nominal_value = None
-            else:
+            raise AttributeError(msg_no_nv.format('storage'))
+
+        # Check flows for nominal value
+        for flow in list(self.inputs.values()) + list(self.outputs.values()):
+            if self.investment and flow.nominal_value is not None:
+                raise AttributeError(msg_no_nv.format('flow'))
+            if (flow.nominal_value is not None and
+                    self.nominal_output_capacity_ratio is not None):
+                msg = ("Duplicate definition! (DRAFT!)"
+                       "fdsfgds")
+                raise AttributeError(msg)
+            if (not self.investment and
+                    self.nominal_output_capacity_ratio is not None):
                 flow.nominal_value = (self.nominal_input_capacity_ratio *
                                       self.nominal_capacity)
             if self.investment:
                 if not isinstance(flow.investment, Investment):
                     flow.investment = Investment()
-
-        # Check output flows for nominal value
-        for flow in self.outputs.values():
-            if flow.nominal_value is not None:
-                storage_nominal_value_warning('input')
-            if self.nominal_capacity is None:
-                flow.nominal_value = None
-            else:
-                flow.nominal_value = (self.nominal_output_capacity_ratio *
-                                      self.nominal_capacity)
-            if self.investment:
-                if not isinstance(flow.investment, Investment):
-                    flow.investment = Investment()
-
-
-def storage_nominal_value_warning(flow):
-    msg = ("The nominal_value should not be set for {0} flows of storages." +
-           "The value will be overwritten by the product of the " +
-           "nominal_capacity and the nominal_{0}_capacity_ratio.")
-    warnings.warn(msg.format(flow), SyntaxWarning)
 
 # ------------------------------------------------------------------------------
 # End of generic storage component

--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -368,6 +368,8 @@ class Constraint_Tests:
         bus1 = solph.Bus(label='Bus1')
         storage = solph.components.GenericStorage(
             label='storage',
+            nominal_input_capacity_ratio=0.2,
+            nominal_output_capacity_ratio=0.2,
             inputs={bus1: solph.Flow()},
             outputs={bus1: solph.Flow()},
             investment=solph.Investment(ep_costs=145))

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -3,9 +3,9 @@ from oemof import solph
 
 
 @tools.raises(AttributeError)
-def test_generic_storage():
+def test_generic_storage_1():
     """Duplicate definition inflow."""
-    bel = solph.Bus(label='bel')
+    bel = solph.Bus()
     solph.components.GenericStorage(
         label='storage',
         nominal_capacity=45,
@@ -19,9 +19,9 @@ def test_generic_storage():
 
 
 @tools.raises(AttributeError)
-def test_generic_storage():
+def test_generic_storage_2():
     """Duplicate definition inflow."""
-    bel = solph.Bus(label='bel')
+    bel = solph.Bus()
     solph.components.GenericStorage(
         label='storage',
         nominal_capacity=45,
@@ -35,9 +35,9 @@ def test_generic_storage():
 
 
 @tools.raises(AttributeError)
-def test_generic_storage():
+def test_generic_storage_3():
     """Nominal value defined with investment model."""
-    bel = solph.Bus(label='bel')
+    bel = solph.Bus()
     solph.components.GenericStorage(
         label='storage',
         nominal_capacity=45,
@@ -49,3 +49,17 @@ def test_generic_storage():
         inflow_conversion_factor=1, outflow_conversion_factor=0.8,
         fixed_costs=35,
         investment=solph.Investment(ep_costs=23))
+
+
+def test_generic_storage_4():
+    """Nominal value defined with investment model."""
+    bel = solph.Bus()
+    solph.components.GenericStorage(
+        label='storage',
+        nominal_capacity=45,
+        inputs={bel: solph.Flow(nominal_value=23, variable_costs=10e10)},
+        outputs={bel: solph.Flow(variable_costs=10e10)},
+        capacity_loss=0.00, initial_capacity=0,
+        nominal_output_capacity_ratio=1/6,
+        inflow_conversion_factor=1, outflow_conversion_factor=0.8,
+        fixed_costs=35)

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -1,0 +1,51 @@
+from nose import tools
+from oemof import solph
+
+
+@tools.raises(AttributeError)
+def test_generic_storage():
+    """Duplicate definition inflow."""
+    bel = solph.Bus(label='bel')
+    solph.components.GenericStorage(
+        label='storage',
+        nominal_capacity=45,
+        inputs={bel: solph.Flow(nominal_value=5, variable_costs=10e10)},
+        outputs={bel: solph.Flow(variable_costs=10e10)},
+        capacity_loss=0.00, initial_capacity=0,
+        nominal_input_capacity_ratio=1/6,
+        nominal_output_capacity_ratio=1/6,
+        inflow_conversion_factor=1, outflow_conversion_factor=0.8,
+        fixed_costs=35)
+
+
+@tools.raises(AttributeError)
+def test_generic_storage():
+    """Duplicate definition inflow."""
+    bel = solph.Bus(label='bel')
+    solph.components.GenericStorage(
+        label='storage',
+        nominal_capacity=45,
+        inputs={bel: solph.Flow(variable_costs=10e10)},
+        outputs={bel: solph.Flow(nominal_value=5, variable_costs=10e10)},
+        capacity_loss=0.00, initial_capacity=0,
+        nominal_input_capacity_ratio=1/6,
+        nominal_output_capacity_ratio=1/6,
+        inflow_conversion_factor=1, outflow_conversion_factor=0.8,
+        fixed_costs=35)
+
+
+@tools.raises(AttributeError)
+def test_generic_storage():
+    """Nominal value defined with investment model."""
+    bel = solph.Bus(label='bel')
+    solph.components.GenericStorage(
+        label='storage',
+        nominal_capacity=45,
+        inputs={bel: solph.Flow(variable_costs=10e10)},
+        outputs={bel: solph.Flow(variable_costs=10e10)},
+        capacity_loss=0.00, initial_capacity=0,
+        nominal_input_capacity_ratio=1/6,
+        nominal_output_capacity_ratio=1/6,
+        inflow_conversion_factor=1, outflow_conversion_factor=0.8,
+        fixed_costs=35,
+        investment=solph.Investment(ep_costs=23))

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -7,7 +7,7 @@ def test_generic_storage_1():
     """Duplicate definition inflow."""
     bel = solph.Bus()
     solph.components.GenericStorage(
-        label='storage',
+        label='storage1',
         nominal_capacity=45,
         inputs={bel: solph.Flow(nominal_value=5, variable_costs=10e10)},
         outputs={bel: solph.Flow(variable_costs=10e10)},
@@ -23,7 +23,7 @@ def test_generic_storage_2():
     """Duplicate definition inflow."""
     bel = solph.Bus()
     solph.components.GenericStorage(
-        label='storage',
+        label='storage2',
         nominal_capacity=45,
         inputs={bel: solph.Flow(variable_costs=10e10)},
         outputs={bel: solph.Flow(nominal_value=5, variable_costs=10e10)},
@@ -39,7 +39,7 @@ def test_generic_storage_3():
     """Nominal value defined with investment model."""
     bel = solph.Bus()
     solph.components.GenericStorage(
-        label='storage',
+        label='storage3',
         nominal_capacity=45,
         inputs={bel: solph.Flow(variable_costs=10e10)},
         outputs={bel: solph.Flow(variable_costs=10e10)},
@@ -55,7 +55,7 @@ def test_generic_storage_4():
     """Nominal value defined with investment model."""
     bel = solph.Bus()
     solph.components.GenericStorage(
-        label='storage',
+        label='storage4',
         nominal_capacity=45,
         inputs={bel: solph.Flow(nominal_value=23, variable_costs=10e10)},
         outputs={bel: solph.Flow(variable_costs=10e10)},


### PR DESCRIPTION
The default value for the `nominal_input_capacity_ratio` (as well output) is now None.
 
```diff
self.nominal_input_capacity_ratio = kwargs.get(
- 'nominal_input_capacity_ratio', 0.2)
+ 'nominal_input_capacity_ratio', None)
```

I added some checks that raise errors if the storage is defined contradictory.

`nominal_value` im Flow AND `nominal_input_capacity_ratio` -> AttributeError
`nominal_value` im Flow OR `nominal_capacity`with investment -> AttributeError

Furthermore I wrote some tests and fixed existing ones to test the behaviour above.

TODO:
We could write a good error message to help users to understand what went wrong. At the moment
there are only drafts.