### PR TITLE
Remove fixed_costs attribute from Flow class

### DIFF
--- a/doc/whatsnew/v0-2-0.rst
+++ b/doc/whatsnew/v0-2-0.rst
@@ -21,6 +21,8 @@ API changes
   <oemof.network.Node>` to an :class:`energy system
   <oemof.energy_system.EnergySystem>`. This option has been made a bit more
   feature rich by the way, but see below for more on this.
+* The `fixed_costs` attribute of the  :class:`nodes <oemof.solph.network.Flow>`
+  has been removed.
 
 New features
 ############

--- a/doc/whatsnew/v0-2-0.rst
+++ b/doc/whatsnew/v0-2-0.rst
@@ -22,7 +22,8 @@ API changes
   <oemof.energy_system.EnergySystem>`. This option has been made a bit more
   feature rich by the way, but see below for more on this.
 * The `fixed_costs` attribute of the  :class:`nodes <oemof.solph.network.Flow>`
-  has been removed.
+  has been removed. For more information see
+  (`Issue #407 <https://github.com/oemof/oemof/issues/407>`_).
 
 New features
 ############

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -72,13 +72,9 @@ class Flow(SimpleBlock):
         .. math::
             \sum_{(i,o)} \sum_t flow(i, o, t) \cdot variable\_costs(i, o, t)
 
-    Additionally, if :attr:`fixed_costs` are set by the user:
-        .. math::
-            \sum_{(i, o)}  nominal\_value(i, o) \cdot fixed\_costs(i, o)
+    The expression can be accessed by :attr:`om.Flow.variable_costs` and
+    their value after optimization by :meth:`om.Flow.variable_costs()` .
 
-    The expression can be accessed by :attr:`om.Flow.fixed_costs` and
-    their value after optimization by :meth:`om.Flow.fixed_costs()` .
-    This works similar for variable costs with :attr:`*.variable_costs`.
     """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -215,7 +211,6 @@ class Flow(SimpleBlock):
         m = self.parent_block()
 
         variable_costs = 0
-        fixed_costs = 0
         gradient_costs = 0
 
         for i, o in m.FLOWS:
@@ -236,13 +231,7 @@ class Flow(SimpleBlock):
                                        m.flows[i, o].negative_gradient[
                                            'costs'])
 
-            # add fixed costs if nominal_value is not None
-            if (m.flows[i, o].fixed_costs and
-                    m.flows[i, o].nominal_value is not None):
-                fixed_costs += (m.flows[i, o].nominal_value *
-                                m.flows[i, o].fixed_costs)
-
-        return fixed_costs + variable_costs + gradient_costs
+        return variable_costs + gradient_costs
 
 
 class InvestmentFlow(SimpleBlock):
@@ -316,13 +305,10 @@ class InvestmentFlow(SimpleBlock):
         .. math::
             \sum_{i, o} invest(i, o) \cdot ep\_costs(i, o)
 
-    Additionally, if :attr:`fixed_costs` are set by the user:
-        .. math::
-            \sum_{i, o} invest(i, o) \cdot fixed\_costs(i,o)
-
-    The expression can be accessed by :attr:`om.InvestmentFlow.fixed_costs` and
-    their value after optimization by :meth:`om.InvestmentFlow.fixed_costs()` .
-    This works similar for variable costs with :attr:`*.variable_costs` etc.
+    The expression can be accessed by :attr:`om.InvestmentFlow.variable_costs`
+    and their value after optimization by
+    :meth:`om.InvestmentFlow.variable_costs()` . This works similar for
+    investment costs with :attr:`*.investment_costs` etc.
     """
 
     def __init__(self, *args, **kwargs):
@@ -434,16 +420,9 @@ class InvestmentFlow(SimpleBlock):
             return 0
 
         m = self.parent_block()
-        fixed_costs = 0
-        variable_costs = 0
         investment_costs = 0
 
         for i, o in self.FLOWS:
-            # fixed costs
-            if m.flows[i, o].fixed_costs is not None:
-                fixed_costs += (self.invest[i, o] *
-                                m.flows[i, o].fixed_costs)
-            # investment costs
             if m.flows[i, o].investment.ep_costs is not None:
                 investment_costs += (self.invest[i, o] *
                                      m.flows[i, o].investment.ep_costs)
@@ -451,10 +430,7 @@ class InvestmentFlow(SimpleBlock):
                 raise ValueError("Missing value for investment costs!")
 
         self.investment_costs = Expression(expr=investment_costs)
-        self.fixed_costs = Expression(expr=fixed_costs)
-        self.variable_costs = Expression(expr=variable_costs)
-
-        return fixed_costs + variable_costs + investment_costs
+        return investment_costs
 
 
 class Bus(SimpleBlock):

--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -93,8 +93,7 @@ class GenericStorage(network.Transformer):
     ...     nominal_input_capacity_ratio=1/6,
     ...     nominal_output_capacity_ratio=1/6,
     ...     inflow_conversion_factor=0.9,
-    ...     outflow_conversion_factor=0.93,
-    ...     fixed_costs=35)
+    ...     outflow_conversion_factor=0.93)
 
     >>> my_investment_storage = solph.components.GenericStorage(
     ...     label='storage',
@@ -126,7 +125,6 @@ class GenericStorage(network.Transformer):
                 'outflow_conversion_factor', 1))
         self.capacity_max = solph_sequence(kwargs.get('capacity_max', 1))
         self.capacity_min = solph_sequence(kwargs.get('capacity_min', 0))
-        self.fixed_costs = kwargs.get('fixed_costs')
         self.investment = kwargs.get('investment')
 
         # General error messages
@@ -208,11 +206,6 @@ class GenericStorageBlock(SimpleBlock):
 
     **The following parts of the objective function are created:**
 
-    If :attr:`fixed_costs` is set by the user:
-        .. math:: \sum_n nominal\_capacity(n, t) \cdot fixed\_costs(n)
-
-    The fixed costs expression can be accessed by `om.Storage.fixed_costs`
-    and their value after optimization by: `om.Storage.fixed_costs()`.
     """
 
     CONSTRAINT_GROUP = True
@@ -274,21 +267,13 @@ class GenericStorageBlock(SimpleBlock):
 
     def _objective_expression(self):
         r"""Objective expression for storages with no investment.
-        Note: This adds only fixed costs as variable costs are already
+        Note: This adds nothing as variable costs are already
         added in the Block :class:`Flow`.
         """
         if not hasattr(self, 'STORAGES'):
             return 0
 
-        fixed_costs = 0
-
-        for n in self.STORAGES:
-            if n.fixed_costs is not None:
-                fixed_costs += n.nominal_capacity * n.fixed_costs
-
-        self.fixed_costs = Expression(expr=fixed_costs)
-
-        return fixed_costs
+        return 0
 
 # ------------------------------------------------------------------------------
 # End of generic storage block
@@ -370,13 +355,10 @@ class GenericInvestmentStorageBlock(SimpleBlock):
         .. math::
             \\sum_n invest(n) \cdot ep\_costs(n)
 
-    Additionally, if fixed costs are set by the user:
-        .. math::
-            \\sum_n invest(n) \cdot fixed\_costs(n)
+    The expression can be accessed by
+    :attr:`om.InvestStorages.investment_costs` and their value after
+    optimization by :meth:`om.InvestStorages.investment_costs()` .
 
-    The expression can be accessed by :attr:`om.InvestStorages.fixed_costs` and
-    their value after optimization by :meth:`om.InvestStorages.fixed_costs()` .
-    This works similar for investment costs with :attr:`*.investment_costs`.
     """
 
     CONSTRAINT_GROUP = True
@@ -493,7 +475,6 @@ class GenericInvestmentStorageBlock(SimpleBlock):
             return 0
 
         investment_costs = 0
-        fixed_costs = 0
 
         for n in self.INVESTSTORAGES:
             if n.investment.ep_costs is not None:
@@ -501,12 +482,9 @@ class GenericInvestmentStorageBlock(SimpleBlock):
             else:
                 raise ValueError("Missing value for investment costs!")
 
-            if n.fixed_costs is not None:
-                fixed_costs += self.invest[n] * n.fixed_costs
         self.investment_costs = Expression(expr=investment_costs)
-        self.fixed_costs = Expression(expr=fixed_costs)
 
-        return fixed_costs + investment_costs
+        return investment_costs
 
 # ------------------------------------------------------------------------------
 # End of generic storage invest block
@@ -572,8 +550,7 @@ class GenericCHP(network.Transformer):
     back_pressure : boolean
         Flag to use back-pressure characteristics. Works of set to `True` and
         `Q_CW_min` set to zero. See paper above for more information.
-    fixed_costs : numerical value
-        Fixed costs for length of optimization period.
+
 
     Notes
     -----
@@ -589,7 +566,6 @@ class GenericCHP(network.Transformer):
         self.heat_output = kwargs.get('heat_output')
         self.Beta = solph_sequence(kwargs.get('Beta'))
         self.back_pressure = kwargs.get('back_pressure')
-        self.fixed_costs = kwargs.get('fixed_costs')
         self._alphas = None
 
         # map specific flows to standard API
@@ -820,25 +796,13 @@ class GenericCHPBlock(SimpleBlock):
     def _objective_expression(self):
         r"""Objective expression for generic CHPs with no investment.
 
-        Note: This adds only fixed costs as variable costs are already
+        Note: This adds nothing as variable costs are already
         added in the Block :class:`Flow`.
         """
         if not hasattr(self, 'GENERICCHPS'):
             return 0
 
-        fixed_costs = 0
-
-        m = self.parent_block()
-
-        for n in self.GENERICCHPS:
-            if n.fixed_costs is not None:
-                P_max = [list(n.electrical_output.values())[0].P_max_woDH[t]
-                         for t in m.TIMESTEPS]
-                fixed_costs += max(P_max) * n.fixed_costs
-
-        self.fixed_costs = Expression(expr=fixed_costs)
-
-        return fixed_costs
+        return 0
 
 # ------------------------------------------------------------------------------
 # End of generic CHP block

--- a/oemof/solph/constraints.py
+++ b/oemof/solph/constraints.py
@@ -6,7 +6,7 @@ __copyright__ = "oemof developer group"
 __license__ = "GPLv3"
 
 import pyomo.environ as po
-
+import logging
 
 def emission_limit(om, flows=None, limit=None):
     """

--- a/oemof/solph/constraints.py
+++ b/oemof/solph/constraints.py
@@ -6,7 +6,7 @@ __copyright__ = "oemof developer group"
 __license__ = "GPLv3"
 
 import pyomo.environ as po
-import logging
+
 
 def emission_limit(om, flows=None, limit=None):
     """

--- a/oemof/solph/network.py
+++ b/oemof/solph/network.py
@@ -83,9 +83,6 @@ class Flow:
         The costs associated with one unit of the flow. If this is set the
         costs will be added to the objective expression of the optimization
         problem.
-    fixed_costs : numeric
-        The costs of the whole period associated with the absolute
-        nominal_value of the flow.
     fixed : boolean
         Boolean value indicating if a flow is fixed during the optimization
         problem to its ex-ante set value. Used in combination with the
@@ -138,13 +135,13 @@ class Flow:
         # E.g. create the variable in the energy system and populate with
         # information afterwards when creating objects.
 
-        scalars = ['nominal_value', 'fixed_costs', 'summed_max', 'summed_min',
+        scalars = ['nominal_value', 'summed_max', 'summed_min',
                    'investment', 'nonconvex', 'integer', 'fixed']
         sequences = ['actual_value', 'positive_gradient', 'negative_gradient',
                      'variable_costs', 'min', 'max']
-        defaults = {'fixed': False, 'min': 0, 'max': 1,
+        defaults = {'fixed': False, 'min': 0, 'max': 1, 'variable_costs': 0,
                     'positive_gradient': {'ub': None, 'costs': 0},
-                    'negative_gradient': {'ub': None, 'costs': 0}
+                    'negative_gradient': {'ub': None, 'costs': 0},
                     }
 
         for attribute in set(scalars + sequences + list(kwargs)):

--- a/oemof/solph/network.py
+++ b/oemof/solph/network.py
@@ -150,7 +150,7 @@ class Flow:
                 setattr(self, attribute, {'ub': sequence(value['ub']),
                                           'costs': value['costs']})
             elif 'fixed_costs' in attribute:
-                raise DeprecationWarning(
+                raise AttributeError(
                          "The `fixed_costs` attribute has been removed"
                          " with v0.2!")
             else:

--- a/oemof/solph/network.py
+++ b/oemof/solph/network.py
@@ -150,7 +150,7 @@ class Flow:
                 setattr(self, attribute, {'ub': sequence(value['ub']),
                                           'costs': value['costs']})
             elif 'fixed_costs' in attribute:
-                raise AttributeError(
+                raise DeprecationWarning(
                          "The `fixed_costs` attribute has been removed"
                          " with v0.2!")
             else:

--- a/oemof/solph/network.py
+++ b/oemof/solph/network.py
@@ -149,6 +149,10 @@ class Flow:
             if 'gradient' in attribute:
                 setattr(self, attribute, {'ub': sequence(value['ub']),
                                           'costs': value['costs']})
+            elif 'fixed_costs' in attribute:
+                raise AttributeError(
+                         "The `fixed_costs` attribute has been removed"
+                         " with v0.2!")
             else:
                 setattr(self, attribute,
                         sequence(value) if attribute in sequences else value)

--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -157,8 +157,7 @@ class Constraint_Tests:
         bel = solph.Bus(label='electricityBus')
 
         solph.Source(label='wind', outputs={bel: solph.Flow(
-            actual_value=[.43, .72, .29], nominal_value=10e5, fixed=True,
-            fixed_costs=20)})
+            actual_value=[.43, .72, .29], nominal_value=10e5, fixed=True)})
 
         solph.Sink(label='excess', inputs={bel: solph.Flow(variable_costs=40)})
 
@@ -179,8 +178,7 @@ class Constraint_Tests:
         bel = solph.Bus(label='electricityBus')
 
         solph.Source(label='wind', outputs={bel: solph.Flow(
-            actual_value=[12, 16, 14], nominal_value=1000000, fixed=True,
-            fixed_costs=20)})
+            actual_value=[12, 16, 14], nominal_value=1000000, fixed=True)})
 
         solph.Sink(label='excess', inputs={bel: solph.Flow(
             summed_max=2.3, variable_costs=25, max=0.8,
@@ -195,7 +193,7 @@ class Constraint_Tests:
         bel = solph.Bus(label='electricityBus')
 
         solph.Source(label='pv', outputs={bel: solph.Flow(
-            max=[45, 83, 65], fixed_costs=20, variable_costs=13,
+            max=[45, 83, 65], variable_costs=13,
             investment=solph.Investment(ep_costs=123))})
 
         solph.Sink(label='excess', inputs={bel: solph.Flow(
@@ -217,8 +215,7 @@ class Constraint_Tests:
             nominal_input_capacity_ratio=1/6,
             nominal_output_capacity_ratio=1/6,
             inflow_conversion_factor=0.97,
-            outflow_conversion_factor=0.86,
-            fixed_costs=35)
+            outflow_conversion_factor=0.86)
 
         self.compare_lp_files('storage.lp')
 
@@ -239,7 +236,6 @@ class Constraint_Tests:
             nominal_output_capacity_ratio=1 / 6,
             inflow_conversion_factor=0.97,
             outflow_conversion_factor=0.86,
-            fixed_costs=35,
             investment=solph.Investment(ep_costs=145, maximum=234))
 
         self.compare_lp_files('storage_invest.lp')

--- a/tests/lp_files/fixed_source_invest_sink.lp
+++ b/tests/lp_files/fixed_source_invest_sink.lp
@@ -6,7 +6,6 @@ objective:
 +25 flow(electricityBus_excess_0)
 +25 flow(electricityBus_excess_1)
 +25 flow(electricityBus_excess_2)
-+20000000 ONE_VAR_CONSTANT
 
 s.t.
 

--- a/tests/lp_files/fixed_source_variable_sink.lp
+++ b/tests/lp_files/fixed_source_variable_sink.lp
@@ -5,7 +5,6 @@ objective:
 +40 flow(electricityBus_excess_0)
 +40 flow(electricityBus_excess_1)
 +40 flow(electricityBus_excess_2)
-+20000000 ONE_VAR_CONSTANT
 
 s.t.
 

--- a/tests/lp_files/invest_source_fixed_sink.lp
+++ b/tests/lp_files/invest_source_fixed_sink.lp
@@ -2,7 +2,7 @@
 
 min 
 objective:
-+143 InvestmentFlow_invest(pv_electricityBus)
++123 InvestmentFlow_invest(pv_electricityBus)
 +13 flow(pv_electricityBus_0)
 +13 flow(pv_electricityBus_1)
 +13 flow(pv_electricityBus_2)

--- a/tests/lp_files/storage.lp
+++ b/tests/lp_files/storage.lp
@@ -8,7 +8,6 @@ objective:
 +24 flow(storage_electricityBus_0)
 +24 flow(storage_electricityBus_1)
 +24 flow(storage_electricityBus_2)
-+3500000 ONE_VAR_CONSTANT
 
 s.t.
 

--- a/tests/lp_files/storage_invest.lp
+++ b/tests/lp_files/storage_invest.lp
@@ -2,7 +2,7 @@
 
 min 
 objective:
-+180 GenericInvestmentStorageBlock_invest(storage)
++145 GenericInvestmentStorageBlock_invest(storage)
 +56 flow(electricityBus_storage_0)
 +56 flow(electricityBus_storage_1)
 +56 flow(electricityBus_storage_2)

--- a/tests/solph_tests.py
+++ b/tests/solph_tests.py
@@ -38,7 +38,7 @@ class Grouping_Tests:
 
         solph.Source(label='Source', outputs={b: solph.Flow(
             actual_value=[12, 16, 14], nominal_value=1000000,
-            fixed=True, fixed_costs=20)})
+            fixed=True)})
 
         solph.Sink(label='Sink', inputs={b: solph.Flow(
             summed_max=2.3, variable_costs=25, max=0.8,

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -52,7 +52,7 @@ def test_generic_storage_3():
         capacity_loss=0.00, initial_capacity=0,
         nominal_input_capacity_ratio=1/6,
         nominal_output_capacity_ratio=1/6,
-        inflow_conversion_factor=1, outflow_conversion_factor=0.8
+        inflow_conversion_factor=1, outflow_conversion_factor=0.8,
         investment=solph.Investment(ep_costs=23))
 
 

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -22,8 +22,7 @@ def test_generic_storage_1():
         capacity_loss=0.00, initial_capacity=0,
         nominal_input_capacity_ratio=1/6,
         nominal_output_capacity_ratio=1/6,
-        inflow_conversion_factor=1, outflow_conversion_factor=0.8,
-        fixed_costs=35)
+        inflow_conversion_factor=1, outflow_conversion_factor=0.8)
 
 
 @tools.raises(AttributeError)
@@ -38,8 +37,7 @@ def test_generic_storage_2():
         capacity_loss=0.00, initial_capacity=0,
         nominal_input_capacity_ratio=1/6,
         nominal_output_capacity_ratio=1/6,
-        inflow_conversion_factor=1, outflow_conversion_factor=0.8,
-        fixed_costs=35)
+        inflow_conversion_factor=1, outflow_conversion_factor=0.8)
 
 
 @tools.raises(AttributeError)
@@ -54,8 +52,7 @@ def test_generic_storage_3():
         capacity_loss=0.00, initial_capacity=0,
         nominal_input_capacity_ratio=1/6,
         nominal_output_capacity_ratio=1/6,
-        inflow_conversion_factor=1, outflow_conversion_factor=0.8,
-        fixed_costs=35,
+        inflow_conversion_factor=1, outflow_conversion_factor=0.8
         investment=solph.Investment(ep_costs=23))
 
 
@@ -69,5 +66,4 @@ def test_generic_storage_4():
         outputs={bel: solph.Flow(variable_costs=10e10)},
         capacity_loss=0.00, initial_capacity=0,
         nominal_output_capacity_ratio=1/6,
-        inflow_conversion_factor=1, outflow_conversion_factor=0.8,
-        fixed_costs=35)
+        inflow_conversion_factor=1, outflow_conversion_factor=0.8)

--- a/tests/test_scripts/test_solph/test_connect_invest/test_connect_invest.py
+++ b/tests/test_scripts/test_solph/test_connect_invest/test_connect_invest.py
@@ -40,8 +40,7 @@ def test_connect_invest():
 
     # create fixed source object representing wind power plants
     solph.Source(label='wind', outputs={bel1: solph.Flow(
-        actual_value=data['wind'], nominal_value=1000000, fixed=True,
-        fixed_costs=20)})
+        actual_value=data['wind'], nominal_value=1000000, fixed=True)})
 
     # create simple sink object representing the electrical demand
     solph.Sink(label='demand', inputs={bel1: solph.Flow(

--- a/tests/test_scripts/test_solph/test_connect_invest/test_connect_invest.py
+++ b/tests/test_scripts/test_solph/test_connect_invest/test_connect_invest.py
@@ -55,7 +55,6 @@ def test_connect_invest():
         nominal_input_capacity_ratio=1/6,
         nominal_output_capacity_ratio=1/6,
         inflow_conversion_factor=1, outflow_conversion_factor=0.8,
-        fixed_costs=35,
         investment=solph.Investment(ep_costs=0.2),
     )
 

--- a/tests/test_scripts/test_solph/test_generic_chp/test_generic_chp.py
+++ b/tests/test_scripts/test_solph/test_generic_chp/test_generic_chp.py
@@ -62,8 +62,7 @@ def test_gen_chp():
             Eta_el_min_woDH=data['Eta_el_min_woDH'])},
         heat_output={bth: solph.Flow(
             Q_CW_min=data['Q_CW_min'])},
-        Beta=data['Beta'], back_pressure=False,
-        fixed_costs=0)
+        Beta=data['Beta'], back_pressure=False)
 
     # create an optimization problem and solve it
     om = solph.Model(es)

--- a/tests/test_scripts/test_solph/test_storage_investment/test_storage_investment.py
+++ b/tests/test_scripts/test_solph/test_storage_investment/test_storage_investment.py
@@ -141,4 +141,4 @@ def test_optimise_storage_size(filename="storage_investment.csv", solver='cbc'):
     eq_(str(meta['problem']['Sense']), 'minimize')
 
     # Objective function
-    eq_(round(meta['objective']), 423167578362035072)
+    eq_(round(meta['objective']), 423167578333305088)

--- a/tests/test_scripts/test_solph/test_storage_investment/test_storage_investment.py
+++ b/tests/test_scripts/test_solph/test_storage_investment/test_storage_investment.py
@@ -141,4 +141,4 @@ def test_optimise_storage_size(filename="storage_investment.csv", solver='cbc'):
     eq_(str(meta['problem']['Sense']), 'minimize')
 
     # Objective function
-    eq_(round(meta['objective']), 423167578333305088)
+    eq_(round(meta['objective']), 423167578261665280)

--- a/tests/test_scripts/test_solph/test_storage_investment/test_storage_investment.py
+++ b/tests/test_scripts/test_solph/test_storage_investment/test_storage_investment.py
@@ -68,12 +68,10 @@ def test_optimise_storage_size(filename="storage_investment.csv", solver='cbc'):
         nominal_value=194397000 * 400 / 8760, summed_max=1)})
 
     solph.Source(label='wind', outputs={bel: solph.Flow(
-        actual_value=data['wind'], nominal_value=1000000, fixed=True,
-        fixed_costs=20)})
+        actual_value=data['wind'], nominal_value=1000000, fixed=True)})
 
     solph.Source(label='pv', outputs={bel: solph.Flow(
-        actual_value=data['pv'], nominal_value=582000, fixed=True,
-        fixed_costs=15)})
+        actual_value=data['pv'], nominal_value=582000, fixed=True)})
 
     # Transformer
     solph.Transformer(
@@ -92,7 +90,6 @@ def test_optimise_storage_size(filename="storage_investment.csv", solver='cbc'):
         nominal_input_capacity_ratio=1/6,
         nominal_output_capacity_ratio=1/6,
         inflow_conversion_factor=1, outflow_conversion_factor=0.8,
-        fixed_costs=35,
         investment=solph.Investment(ep_costs=epc),
     )
 

--- a/tests/test_solph_network_classes.py
+++ b/tests/test_solph_network_classes.py
@@ -34,3 +34,5 @@ def test_flow_classes():
         solph.Flow(investment=solph.Investment(), nominal_value=4)
     with assert_raises(ValueError):
         solph.Flow(investment=solph.Investment(), nonconvex=solph.NonConvex())
+    with assert_raises(AttributeError):
+        solph.Flow(fixed_costs=34)


### PR DESCRIPTION
As this attribute is not necessarily needed but might be confusing in investment models we would like to remove it. This came up in PR #396 but I think it is cleaner to create a separate PR.

@oemof/oemof-solph Any objections?