### PR TITLE
Improve developer welcome

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,11 +49,16 @@ You can find a repository with all currently available examples for oemof on git
 
 You are welcome to contribute your own examples via a `pull request <https://github.com/oemof/examples/pulls>`_ or by sending us an e-mail (see `here <https://oemof.org/contact/>`_ for contact information).
 
-Got further questions regarding oemof? 
+Got further questions on using oemof? 
 ======================================
 If you have questions regarding the use of oemof you can visit the forum at: `https://forum.openmod-initiative.org/tags/c/qa/oemof` and open a new thread if your questions hasn't been already answered.
 
-If you have questions regarding collaboration like code development or documentation fixing please use the issues on github.
+Join the developers!
+===================
+
+A warm welcome to all who want to join the developers and contribute to oemof. Information
+on the details and how to approach us can be found 
+`in the documentation <http://oemof.readthedocs.io/en/latest/developing_oemof.html>`_ .
 
 
 Keep in touch

--- a/doc/developing_oemof.rst
+++ b/doc/developing_oemof.rst
@@ -7,7 +7,9 @@ Oemof is developed collaboratively and therefore driven by its community. While 
 as a user of oemof, you may find situations that demand solutions that are not readily
 available. In this case, your solution may be of help to other users as well. Contributing
 to the development of oemof is good for two reasons: Your code may help others and you
-increase the quality of your code through the review of other developers.
+increase the quality of your code through the review of other developers. Note also these
+arguments on
+`why you should contribute <http://oemof.readthedocs.io/en/latest/about_oemof.html?highlight=why%20should#why-should-i-contribute>`_
 
 A first step to get involved with development can be contributing a component that is
 not part of the current version that you defined for your energy system. We have a module

--- a/doc/developing_oemof.rst
+++ b/doc/developing_oemof.rst
@@ -92,13 +92,13 @@ Run the following test before pushing a successful merge.
 Issue-Management
 ----------------
 
-A good means for communication with the developer group are the issues. If you
+A good way for communication with the developer group are issues. If you
 find a bug, want to contribute an enhancement or have a question on a specific problem
 in development you want to discuss, please create an issue:
 
-* create an issue describing your point accurately
-* use the list of tags to choose from to categorize your issue
-* address other developers
+* describing your point accurately
+* using the list of category tags
+* addressing other developers
 
 If you want to address other developers you can use @name-of-developer, or
 use e.g. @oemof-solph to address a team. `Here <https://github.com/orgs/oemof/teams>`_

--- a/doc/developing_oemof.rst
+++ b/doc/developing_oemof.rst
@@ -3,9 +3,28 @@
 Developing oemof
 ================
 
-Here you find important notes for developing oemof and elements within
-the framework. We highly encourage you to contribute to further development 
-of oemof. If you want to collaborate see description below or contact us.
+Oemof is developed collaboratively and therefore driven by its community. While advancing
+as a user of oemof, you may find situations that demand solutions that are not readily
+available. In this case, your solution may be of help to other users as well. Contributing
+to the development of oemof is good for two reasons: Your code may help others and you
+increase the quality of your code through the review of other developers.
+
+A first step to get involved with development can be contributing a component that is
+not part of the current version that you defined for your energy system. We have a module
+oemof.solph.custom that is dedicated to collect custom components created by users. Feel free
+to start a pull request and contribute.
+
+Another way to join the developers and learn how to contribute is to help improve the documentation.
+If you find that some part could be more clear or if you even find a mistake, please
+consider fixing it and creating a pull request.
+
+New developments that provide new functionality may enter oemof at different locations.
+Please feel free to discuss contributions by creating a pull request or an issue.
+
+In the following you find important notes for developing oemof and elements within
+the framework. On whatever level you may want to start, we highly encourage you
+to contribute to the further development of oemof. If you want to collaborate see 
+description below or contact us.
 
 .. contents::
     :depth: 1
@@ -67,6 +86,23 @@ Run the following test before pushing a successful merge.
     python3 path/to/oemof/examples/oemof_full_check.py
 
 .. _style_guidlines_label:
+
+Issue-Management
+----------------
+
+A good means for communication with the developer group are the issues. If you
+find a bug, want to contribute an enhancement or have a question on a specific problem
+in development you want to discuss, please create an issue:
+
+* create an issue describing your point accurately
+* use the list of tags to choose from to categorize your issue
+* address other developers
+
+If you want to address other developers you can use @name-of-developer, or
+use e.g. @oemof-solph to address a team. `Here <https://github.com/orgs/oemof/teams>`_
+you can find an overview over existing teams on different subjects and their members.
+
+Look at the existing issues to get an idea on the usage of issues.
 
 Style guidelines
 ----------------
@@ -151,11 +187,7 @@ Commit message
 
 Use this nice little `commit tutorial <http://chris.beams.io/posts/git-commit/>`_ to 
 learn how to write a nice commit message.
-
-Issue-Management
-----------------
-Section about workflow for issues is still missing (when to assign an issue with
-what kind of tracker to whom etc.).
+ 
 
 Documentation
 ----------------

--- a/doc/developing_oemof.rst
+++ b/doc/developing_oemof.rst
@@ -7,9 +7,9 @@ Oemof is developed collaboratively and therefore driven by its community. While 
 as a user of oemof, you may find situations that demand solutions that are not readily
 available. In this case, your solution may be of help to other users as well. Contributing
 to the development of oemof is good for two reasons: Your code may help others and you
-increase the quality of your code through the review of other developers. Note also these
+increase the quality of your code through the review of other developers. Read also these
 arguments on
-`why you should contribute <http://oemof.readthedocs.io/en/latest/about_oemof.html?highlight=why%20should#why-should-i-contribute>`_
+`why you should contribute <http://oemof.readthedocs.io/en/latest/about_oemof.html?highlight=why%20should#why-should-i-contribute>`_.
 
 A first step to get involved with development can be contributing a component that is
 not part of the current version that you defined for your energy system. We have a module


### PR DESCRIPTION
I added a new section on developing in README.txt and extended developing_oemof.rst:
Now there is a welcome sentence to tell about the possibilities to become a developer.
I also expanded section on issues and put it directly under pull requests as those are the two ways to communicate.

Apart from this, I wonder if the section on pull requests still describes the workflow how we understand it now. We could add a bullet point on how to invite reviewers (how many, whom,..) Also, is the section on tests still up to date?