### PR TITLE
move key-conversion-function from views to processing module

### DIFF
--- a/oemof/outputlib/processing.py
+++ b/oemof/outputlib/processing.py
@@ -144,6 +144,18 @@ def results(om):
     return result
 
 
+def convert_keys_to_strings(result):
+    """
+    Convert the dictionary keys to strings.
+
+    All tuple keys of the result object e.g. results[(pp1, bus1)] are converted
+    into strings that represent the object labels e.g. results[('pp1','bus1')].
+    """
+    converted = {tuple([str(e) for e in k]): v for k, v in result.items()}
+
+    return converted
+
+
 def meta_results(om, undefined=False):
     """
     Fetch some meta data from the Solver. Feel free to add more keys.

--- a/oemof/outputlib/views.py
+++ b/oemof/outputlib/views.py
@@ -9,18 +9,7 @@ __copyright__ = "oemof developer group"
 __license__ = "GPLv3"
 
 import pandas as pd
-
-
-def convert_keys_to_strings(results):
-    """
-    Convert the dictionary keys to strings.
-
-    All tuple keys of the result object e.g. results[(pp1, bus1)] are converted
-    into strings that represent the object labels e.g. results[('pp1','bus1')].
-    """
-    converted = {tuple([str(e) for e in k]): v for k, v in results.items()}
-
-    return converted
+from oemof.outputlib.processing import convert_keys_to_strings
 
 
 def node(results, node):


### PR DESCRIPTION
The conversion of the results keys belongs to processing rather than to views.