### PR TITLE
change attribut group to dictionary

### DIFF
--- a/oemof/solph/network.py
+++ b/oemof/solph/network.py
@@ -68,12 +68,18 @@ class Flow:
         nominal\_value to get the absolute value. If fixed attr is set to True
         the flow variable will be fixed to actual_value * :attr:`nominal_value`
         , I.e. this value is set exogenous.
-    positive_gradient : numeric (sequence or scalar)
-        The normed maximal positive difference (flow[t-1] < flow[t])
-        of two consecutive flow values.
-    negative_gradient : numeric (sequence or scalar)
-        The normed maximum negative difference (from[t-1] > flow[t]) of two
-        consecutive timesteps.
+    positive_gradient : dictionary
+        Two obligate keys:
+        'ub': numeric (sequence, scalar or None), the normed maximal positive
+         difference (flow[t-1] < flow[t]) of two consecutive flow values
+         (ub = upper bound).
+        'costs': numeric (scalar or None), the gradient cost per unit.
+    negative_gradient : dictionary
+        Two obligate keys:
+        'ub': numeric (sequence, scalar or None), the normed maximal negative
+         difference (flow[t-1] > flow[t]) of two consecutive flow values
+         (ub = upper bound).
+        'costs': numeric (scalar or None), the gradient cost per unit.
     summed_max : numeric
         Specific maximum value summed over all timesteps. Will be multiplied
         with the nominal_value to get the absolute limit.

--- a/oemof/solph/network.py
+++ b/oemof/solph/network.py
@@ -218,13 +218,13 @@ class Transformer(on.Transformer):
     Defining an linear transformer:
 
     >>> from oemof import solph
-    >>> bgas = solph.Bus(label="natural_gas")
-    >>> bcoal = solph.Bus(label="hard_coal")
-    >>> bel = solph.Bus(label="electricity")
-    >>> bheat = solph.Bus(label="heat")
+    >>> bgas = solph.Bus(label='natural_gas')
+    >>> bcoal = solph.Bus(label='hard_coal')
+    >>> bel = solph.Bus(label='electricity')
+    >>> bheat = solph.Bus(label='heat')
 
     >>> trsf = solph.Transformer(
-    ...    label="pp_gas_1",
+    ...    label='pp_gas_1',
     ...    inputs={bgas: solph.Flow(), bcoal: solph.Flow()},
     ...    outputs={bel: solph.Flow(), bheat: solph.Flow()},
     ...    conversion_factors={bel: 0.3, bheat: 0.5,
@@ -239,7 +239,7 @@ class Transformer(on.Transformer):
     ['hard_coal', 'natural_gas']
 
     >>> trsf_new = solph.Transformer(
-    ...    label="pp_gas_2",
+    ...    label='pp_gas_2',
     ...    inputs={bgas: solph.Flow()},
     ...    outputs={bel: solph.Flow(), bheat: solph.Flow()},
     ...    conversion_factors={bel: 0.3, bheat: 0.5})

--- a/oemof/solph/network.py
+++ b/oemof/solph/network.py
@@ -137,16 +137,16 @@ class Flow:
 
         scalars = ['nominal_value', 'summed_max', 'summed_min',
                    'investment', 'nonconvex', 'integer', 'fixed']
-        sequences = ['actual_value', 'positive_gradient', 'negative_gradient',
-                     'variable_costs', 'min', 'max']
+        sequences = ['actual_value', 'variable_costs', 'min', 'max']
+        dictionaries = ['positive_gradient', 'negative_gradient']
         defaults = {'fixed': False, 'min': 0, 'max': 1, 'variable_costs': 0,
                     'positive_gradient': {'ub': None, 'costs': 0},
                     'negative_gradient': {'ub': None, 'costs': 0},
                     }
 
-        for attribute in set(scalars + sequences + list(kwargs)):
+        for attribute in set(scalars + sequences + dictionaries + list(kwargs)):
             value = kwargs.get(attribute, defaults.get(attribute))
-            if 'gradient' in attribute:
+            if attribute in dictionaries:
                 setattr(self, attribute, {'ub': sequence(value['ub']),
                                           'costs': value['costs']})
             elif 'fixed_costs' in attribute:


### PR DESCRIPTION
With the negative/positive gradient we added dictionaries as attributes to the Flow class.

In the constructor they are named "sequences". I just stumbled over it searching for something else, but naming types correctly make things clearer.

If we have more dictionaries in the future we can distinguish between them within the if statement:

```python
if attribute in dictionaries:
    if attribute in typ_a_dictionary:
        do something
    elif attribute in typ_b_dictionary:
        do something else
elif:
    ....
```
As long as we do have just one type of dictionaries the second if statement is left out.
