### PR TITLE
Revision/expanding sequences Sequences with default value get not expanded

### DIFF
--- a/oemof/outputlib/processing.py
+++ b/oemof/outputlib/processing.py
@@ -259,6 +259,10 @@ def __separate_attrs(om, get_flows=False, exclude_none=True):
             except TypeError:
                 com['scalars'][key] = value
                 del com['sequences'][key]
+            else:
+                if len(value) == 0:
+                    com['scalars'][key] = value.default
+                    del com['sequences'][key]
 
     def remove_nones(com):
         for key, value in list(com['scalars'].items()):

--- a/oemof/outputlib/processing.py
+++ b/oemof/outputlib/processing.py
@@ -260,9 +260,12 @@ def __separate_attrs(om, get_flows=False, exclude_none=True):
                 com['scalars'][key] = value
                 del com['sequences'][key]
             else:
-                if len(value) == 0:
-                    com['scalars'][key] = value.default
-                    del com['sequences'][key]
+                try:
+                    if not value.default_changed:
+                        com['scalars'][key] = value.default
+                        del com['sequences'][key]
+                except AttributeError:
+                    pass
 
     def remove_nones(com):
         for key, value in list(com['scalars'].items()):

--- a/oemof/solph/plumbing.py
+++ b/oemof/solph/plumbing.py
@@ -96,11 +96,16 @@ class _Sequence(UserList):
     def __init_list(self):
         self.data = [self.default] * (self.highest_index + 1)
 
+    def __repr__(self):
+        if self.default_changed:
+            return super(_Sequence, self).__repr__()
+        return str([i for i in self])
+
     def __len__(self):
         return max(len(self.data), self.highest_index + 1)
 
     def __iter__(self):
         if self.default_changed:
-            super(_Sequence, self).__iter__()
+            return super(_Sequence, self).__iter__()
         else:
             return repeat(self.default, self.highest_index + 1)

--- a/oemof/solph/plumbing.py
+++ b/oemof/solph/plumbing.py
@@ -65,9 +65,12 @@ class _Sequence(UserList):
     """
     def __init__(self, *args, **kwargs):
         self.default = kwargs["default"]
+        self.default_changed = False
         super().__init__(*args)
 
     def __getitem__(self, key):
+        if not self.default_changed:
+            return self.default
         try:
             return self.data[key]
         except IndexError:
@@ -75,6 +78,7 @@ class _Sequence(UserList):
             return self.data[key]
 
     def __setitem__(self, key, value):
+        self.default_changed = True
         try:
             self.data[key] = value
         except IndexError:

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -77,16 +77,16 @@ class Parameter_Result_Tests:
                 'nominal_value': 1,
                 'fixed': True,
                 'negative_gradient_costs': 0,
-                'positive_gradient_costs': 0
+                'positive_gradient_costs': 0,
+                'max': 1,
+                'min': 0,
+                'variable_costs': 0
             }
         )
         eq_(
             param_results[(b_el2, demand)]['sequences'],
             {
-                'actual_value': self.demand_values,
-                'max': [1] * 24,
-                'min': [0] * 24,
-                'variable_costs': [0] * 24
+                'actual_value': self.demand_values
             }
         )
 
@@ -98,7 +98,12 @@ class Parameter_Result_Tests:
             'nominal_value': 1,
             'fixed': True,
             'negative_gradient_costs': 0,
-            'positive_gradient_costs': 0
+            'positive_gradient_costs': 0,
+            'max': 1,
+            'min': 0,
+            'variable_costs': 0,
+            'positive_gradient_ub': None,
+            'negative_gradient_ub': None
         }
         default_scalars = [
             'nominal_value', 'summed_max', 'summed_min',
@@ -113,13 +118,9 @@ class Parameter_Result_Tests:
         )
         sequences_attributes = {
             'actual_value': self.demand_values,
-            'max': [1] * 24,
-            'min': [0] * 24,
-            'variable_costs': [0] * 24
         }
         default_sequences = [
-            'actual_value', 'positive_gradient_ub', 'negative_gradient_ub',
-            'variable_costs', 'min', 'max'
+            'actual_value'
         ]
         for attr in default_sequences:
             if attr not in sequences_attributes:
@@ -141,18 +142,17 @@ class Parameter_Result_Tests:
                 'nominal_output_capacity_ratio': 1 / 6,
                 'investment_ep_costs': 0.4,
                 'investment_maximum': float('inf'),
-                'investment_minimum': 0
+                'investment_minimum': 0,
+                'capacity_loss': 0,
+                'capacity_min': 0,
+                'capacity_max': 1,
+                'inflow_conversion_factor': 1,
+                'outflow_conversion_factor': 0.8,
             }
         )
         eq_(
             param_results[('storage', 'None')]['sequences'],
-            {
-                'capacity_loss': [0.0] * 24,
-                'capacity_min': [0.0] * 24,
-                'capacity_max': [1.0] * 24,
-                'inflow_conversion_factor': [1] * 24,
-                'outflow_conversion_factor': [0.8] * 24,
-            }
+            {}
         )
 
     def test_nodes_without_none_exclusion(self):
@@ -163,12 +163,11 @@ class Parameter_Result_Tests:
             param_results[(diesel, None)]['scalars'],
             {
                 'label': 'diesel',
+                'conversion_factors_b_el1': 2,
+                'conversion_factors_b_diesel': 1,
             }
         )
         eq_(
             param_results[(diesel, None)]['sequences'],
-            {
-                'conversion_factors_b_el1': [2] * 24,
-                'conversion_factors_b_diesel': [1] * 24,
-            }
+            {}
         )


### PR DESCRIPTION
### This revision aims to reduce unnecessary list extensions while creating the model - see related issue #436. 

**Related issue**: #436 
**Located in**: Major change was made to `oemof.solph.plumbing`
**Functionality**:
While building the sequence an internal attribute `self.default_changed` is set to False. Whenever `__getitem__` of sequence is called, only the default value is returned. Before, every time an internal list was extended to requested index. Only, if `__setitem__` is called attribute `self.default_changed` is set to True and an internal list is build, as the sequence no longer consists of only one default value.
**Outcome**:
This revision leads to three things:
1. Testing run-time decreased! (for me, from 8sec to 5sec!) :)
2. `__len__` function of Sequences with only one default value now returns 0 - this is no problem for all tests, but users looking into solph components may get different results.
3. I changed param_results-API, so that Sequences containing only the default value are now added to the 'scalars' dictionary.

**Not implemented**:
The other idea from #436, setting up a list containing entries for every time-step is not implemented and maybe even unnecessary, due to new implementation!

I think these changes are good, improving oemof solph! What do you think?
