### PR TITLE
change licence into REUSE format

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'oemof'
-copyright = u'2014, oemof-Team'
+copyright = u'2014-2018, oemof-developer-team'
 author = u'oemof-Team'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'oemof'
-copyright = u'2014-2018, oemof-developer-team'
+copyright = u'2014-2018, oemof-developer-group'
 author = u'oemof-Team'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/oemof/energy_system.py
+++ b/oemof/energy_system.py
@@ -2,8 +2,9 @@
 
 """Basic EnergySystem class
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/oemof/energy_system.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/energy_system.py
+++ b/oemof/energy_system.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 
 """Basic EnergySystem class
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 from functools import partial
 import logging

--- a/oemof/energy_system.py
+++ b/oemof/energy_system.py
@@ -2,9 +2,9 @@
 
 """Basic EnergySystem class
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/oemof/energy_system.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/oemof/energy_system.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/graph.py
+++ b/oemof/graph.py
@@ -2,8 +2,9 @@
 
 """Modules for creating and analysing energy system graphs.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/oemof/graph.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/graph.py
+++ b/oemof/graph.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 
-"""Modules for creating and analysing energy system graphs."""
+"""Modules for creating and analysing energy system graphs.
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 import networkx as nx
 

--- a/oemof/graph.py
+++ b/oemof/graph.py
@@ -2,9 +2,9 @@
 
 """Modules for creating and analysing energy system graphs.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/oemof/graph.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/oemof/graph.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/groupings.py
+++ b/oemof/groupings.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 
 """ All you need to create groups of stuff in your energy system.
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 try:
     from collections.abc import (Hashable, Iterable, Mapping,

--- a/oemof/groupings.py
+++ b/oemof/groupings.py
@@ -2,8 +2,9 @@
 
 """ All you need to create groups of stuff in your energy system.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/oemof/groupings.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/groupings.py
+++ b/oemof/groupings.py
@@ -2,9 +2,9 @@
 
 """ All you need to create groups of stuff in your energy system.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/oemof/groupings.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/oemof/groupings.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/network.py
+++ b/oemof/network.py
@@ -5,9 +5,9 @@ energy systems. An energy system is modelled as a graph/network of entities
 with very specific constraints on which types of entities are allowed to be
 connected.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/oemof/network.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/oemof/network.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/network.py
+++ b/oemof/network.py
@@ -4,10 +4,12 @@
 energy systems. An energy system is modelled as a graph/network of entities
 with very specific constraints on which types of entities are allowed to be
 connected.
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 from collections import MutableMapping as MM
 from contextlib import contextmanager

--- a/oemof/network.py
+++ b/oemof/network.py
@@ -5,8 +5,9 @@ energy systems. An energy system is modelled as a graph/network of entities
 with very specific constraints on which types of entities are allowed to be
 connected.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/oemof/network.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/outputlib/processing.py
+++ b/oemof/outputlib/processing.py
@@ -4,8 +4,9 @@
 
 Information about the possible usage is provided within the examples.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/oemof/outputlib/processing.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/outputlib/processing.py
+++ b/oemof/outputlib/processing.py
@@ -3,10 +3,12 @@
 """Modules for providing a convenient data structure for solph results.
 
 Information about the possible usage is provided within the examples.
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 import pandas as pd
 from oemof.network import Node

--- a/oemof/outputlib/processing.py
+++ b/oemof/outputlib/processing.py
@@ -4,9 +4,9 @@
 
 Information about the possible usage is provided within the examples.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/oemof/outputlib/processing.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/oemof/outputlib/processing.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/outputlib/views.py
+++ b/oemof/outputlib/views.py
@@ -4,8 +4,9 @@
 
 Information about the possible usage is provided within the examples.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/oemof/outputlib/views.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/outputlib/views.py
+++ b/oemof/outputlib/views.py
@@ -3,10 +3,12 @@
 """Modules for providing convenient views for solph results.
 
 Information about the possible usage is provided within the examples.
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 import pandas as pd
 from oemof.outputlib.processing import convert_keys_to_strings

--- a/oemof/outputlib/views.py
+++ b/oemof/outputlib/views.py
@@ -4,9 +4,9 @@
 
 Information about the possible usage is provided within the examples.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/oemof/outputlib/views.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/oemof/outputlib/views.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -2,10 +2,12 @@
 
 """Creating sets, variables, constraints and parts of the objective function
 for the specified groups.
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 from pyomo.core import (Var, Set, Constraint, BuildAction, Expression,
                         NonNegativeReals, Binary, NonNegativeIntegers)

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -3,9 +3,9 @@
 """Creating sets, variables, constraints and parts of the objective function
 for the specified groups.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/oemof/solph/blocks.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/oemof/solph/blocks.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -3,8 +3,9 @@
 """Creating sets, variables, constraints and parts of the objective function
 for the specified groups.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/oemof/solph/blocks.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -4,8 +4,9 @@
 associated individual constraints (blocks) and groupings. Therefore this
 module holds the class definition and the block directly located by each other.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/oemof/solph/components.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -4,9 +4,9 @@
 associated individual constraints (blocks) and groupings. Therefore this
 module holds the class definition and the block directly located by each other.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/oemof/solph/components.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/oemof/solph/components.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -3,10 +3,12 @@
 """This module is designed to hold custom components with their classes and
 associated individual constraints (blocks) and groupings. Therefore this
 module holds the class definition and the block directly located by each other.
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 import numpy as np
 from pyomo.core.base.block import SimpleBlock

--- a/oemof/solph/constraints.py
+++ b/oemof/solph/constraints.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
 """Additional constraints to be used in an oemof energy model.
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/oemof/solph/constraints.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/oemof/solph/constraints.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/solph/constraints.py
+++ b/oemof/solph/constraints.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 
-"""Additional constraints to be used in an oemof energy model."""
+"""Additional constraints to be used in an oemof energy model.
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 import pyomo.environ as po
 

--- a/oemof/solph/constraints.py
+++ b/oemof/solph/constraints.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
 """Additional constraints to be used in an oemof energy model.
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/oemof/solph/constraints.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/solph/custom.py
+++ b/oemof/solph/custom.py
@@ -4,9 +4,9 @@
 associated individual constraints (blocks) and groupings. Therefore this
 module holds the class definition and the block directly located by each other.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/oemof/solph/custom.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/oemof/solph/custom.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/solph/custom.py
+++ b/oemof/solph/custom.py
@@ -3,10 +3,12 @@
 """This module is designed to hold custom components with their classes and
 associated individual constraints (blocks) and groupings. Therefore this
 module holds the class definition and the block directly located by each other.
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 from pyomo.core.base.block import SimpleBlock
 from pyomo.environ import (Binary, Set, NonNegativeReals, Var, Constraint,

--- a/oemof/solph/custom.py
+++ b/oemof/solph/custom.py
@@ -4,8 +4,9 @@
 associated individual constraints (blocks) and groupings. Therefore this
 module holds the class definition and the block directly located by each other.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/oemof/solph/custom.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/solph/facades.py
+++ b/oemof/solph/facades.py
@@ -4,9 +4,9 @@
 energy specific interfaces (facades) for solph components to simplify its
 application.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/oemof/solph/facades.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/oemof/solph/facades.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/solph/facades.py
+++ b/oemof/solph/facades.py
@@ -3,7 +3,9 @@
 """ This module is designed to contain classes that act as simplified / reduced
 energy specific interfaces (facades) for solph components to simplify its
 application.
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""

--- a/oemof/solph/facades.py
+++ b/oemof/solph/facades.py
@@ -4,8 +4,9 @@
 energy specific interfaces (facades) for solph components to simplify its
 application.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/oemof/solph/facades.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/solph/groupings.py
+++ b/oemof/solph/groupings.py
@@ -12,9 +12,9 @@ groupings specified like this:
     energy_system = EnergySystem(groupings=solph.GROUPINGS)
 
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/oemof/solph/groupings.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/oemof/solph/groupings.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/solph/groupings.py
+++ b/oemof/solph/groupings.py
@@ -12,8 +12,9 @@ groupings specified like this:
     energy_system = EnergySystem(groupings=solph.GROUPINGS)
 
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/oemof/solph/groupings.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/solph/groupings.py
+++ b/oemof/solph/groupings.py
@@ -11,10 +11,12 @@ groupings specified like this:
 
     energy_system = EnergySystem(groupings=solph.GROUPINGS)
 
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 from oemof.solph.network import Bus, Transformer
 from oemof.solph import blocks

--- a/oemof/solph/models.py
+++ b/oemof/solph/models.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 """Solph Optimization Models
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/oemof/solph/models.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/oemof/solph/models.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/solph/models.py
+++ b/oemof/solph/models.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 """Solph Optimization Models
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/oemof/solph/models.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/solph/models.py
+++ b/oemof/solph/models.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
 """Solph Optimization Models
+
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
 """
 
 import pyomo.environ as po
@@ -9,9 +14,6 @@ from oemof.solph import blocks, custom
 from oemof.solph.plumbing import sequence
 from oemof.outputlib import processing
 import logging
-
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
 
 
 class BaseModel(po.ConcreteModel):

--- a/oemof/solph/network.py
+++ b/oemof/solph/network.py
@@ -7,8 +7,9 @@ optimization tasks. An energy system is modelled as a graph/network of nodes
 with very specific constraints on which types of nodes are allowed to be
 connected.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/oemof/solph/network.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/solph/network.py
+++ b/oemof/solph/network.py
@@ -6,9 +6,12 @@ Classes are derived from oemof core network classes and adapted for specific
 optimization tasks. An energy system is modelled as a graph/network of nodes
 with very specific constraints on which types of nodes are allowed to be
 connected.
+
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
 """
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
 
 import oemof.network as on
 import oemof.energy_system as es

--- a/oemof/solph/network.py
+++ b/oemof/solph/network.py
@@ -7,9 +7,9 @@ optimization tasks. An energy system is modelled as a graph/network of nodes
 with very specific constraints on which types of nodes are allowed to be
 connected.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/oemof/solph/network.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/oemof/solph/network.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/solph/options.py
+++ b/oemof/solph/options.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
 """Optional classes to be added to a network class.
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/oemof/solph/options.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/oemof/solph/options.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/solph/options.py
+++ b/oemof/solph/options.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 
-"""Optional classes to be added to a network class."""
+"""Optional classes to be added to a network class.
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 
 class Investment:

--- a/oemof/solph/options.py
+++ b/oemof/solph/options.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
 """Optional classes to be added to a network class.
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/oemof/solph/options.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/solph/plumbing.py
+++ b/oemof/solph/plumbing.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 
 """Plumbing stuff.
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 from collections import abc, UserList
 

--- a/oemof/solph/plumbing.py
+++ b/oemof/solph/plumbing.py
@@ -2,8 +2,9 @@
 
 """Plumbing stuff.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/oemof/solph/plumbing.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/solph/plumbing.py
+++ b/oemof/solph/plumbing.py
@@ -2,9 +2,9 @@
 
 """Plumbing stuff.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/oemof/solph/plumbing.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/oemof/solph/plumbing.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/tools/economics.py
+++ b/oemof/tools/economics.py
@@ -2,9 +2,9 @@
 
 """Module to collect useful functions for economic calculation.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/oemof/tools/economics.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/oemof/tools/economics.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/tools/economics.py
+++ b/oemof/tools/economics.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 
 """Module to collect useful functions for economic calculation.
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 
 def annuity(capex, n, wacc):

--- a/oemof/tools/economics.py
+++ b/oemof/tools/economics.py
@@ -2,8 +2,9 @@
 
 """Module to collect useful functions for economic calculation.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/oemof/tools/economics.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/tools/helpers.py
+++ b/oemof/tools/helpers.py
@@ -4,9 +4,9 @@ This is a collection of helper functions which work on their own and can be
 used by various classes. If there are too many helper-functions, they will
 be sorted in different modules.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/oemof/tools/helpers.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/oemof/tools/helpers.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/tools/helpers.py
+++ b/oemof/tools/helpers.py
@@ -3,10 +3,12 @@
 This is a collection of helper functions which work on their own and can be
 used by various classes. If there are too many helper-functions, they will
 be sorted in different modules.
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 import os
 from collections import MutableMapping

--- a/oemof/tools/helpers.py
+++ b/oemof/tools/helpers.py
@@ -4,8 +4,9 @@ This is a collection of helper functions which work on their own and can be
 used by various classes. If there are too many helper-functions, they will
 be sorted in different modules.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/oemof/tools/helpers.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/tools/logger.py
+++ b/oemof/tools/logger.py
@@ -2,9 +2,9 @@
 
 """Helpers to log your modeling process with oemof.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/oemof/tools/logger.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/oemof/tools/logger.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/tools/logger.py
+++ b/oemof/tools/logger.py
@@ -2,8 +2,9 @@
 
 """Helpers to log your modeling process with oemof.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/oemof/tools/logger.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/oemof/tools/logger.py
+++ b/oemof/tools/logger.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8
 
 """Helpers to log your modeling process with oemof.
+
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
 """
 
 import os

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
 #! /usr/bin/env python
 
-"""TODO: Maybe add a docstring containing a long description for oemof?
+"""
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/tests/test_scripts/test_solph/
+test_variable_chp/test_variable_chp.py
 
-  This would double as something we could put int the `long_description`
-  parameter for `setup` and it would squelch some complaints pylint has on
-  `setup.py`.
-
+SPDX-License-Identifier: GPL-3.0-or-later
 """
 
 from setuptools import find_packages, setup

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 #! /usr/bin/env python
 
 """
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/tests/test_scripts/test_solph/
-test_variable_chp/test_variable_chp.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/setup.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/basic_tests.py
+++ b/tests/basic_tests.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -
 
 """Basic tests.
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 try:
     from collections.abc import Iterable

--- a/tests/basic_tests.py
+++ b/tests/basic_tests.py
@@ -2,9 +2,9 @@
 
 """Basic tests.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/tests/basic_tests.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/tests/basic_tests.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/basic_tests.py
+++ b/tests/basic_tests.py
@@ -2,8 +2,9 @@
 
 """Basic tests.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/tests/basic_tests.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -2,9 +2,9 @@
 
 """Test the created constraints against approved constraints.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/tests/constraint_tests.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/tests/constraint_tests.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -2,8 +2,9 @@
 
 """Test the created constraints against approved constraints.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/tests/constraint_tests.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -
 
 """Test the created constraints against approved constraints.
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 from difflib import unified_diff
 import logging

--- a/tests/regression_tests.py
+++ b/tests/regression_tests.py
@@ -2,9 +2,9 @@
 
 """Regression tests.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/tests/regression_tests.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/tests/regression_tests.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/regression_tests.py
+++ b/tests/regression_tests.py
@@ -2,8 +2,9 @@
 
 """Regression tests.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/tests/regression_tests.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/regression_tests.py
+++ b/tests/regression_tests.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -
 
 """Regression tests.
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 import logging
 

--- a/tests/solph_tests.py
+++ b/tests/solph_tests.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -
 
 """Grouping tests.
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 from nose.tools import ok_, eq_
 

--- a/tests/solph_tests.py
+++ b/tests/solph_tests.py
@@ -2,8 +2,9 @@
 
 """Grouping tests.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/tests/solph_tests.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/solph_tests.py
+++ b/tests/solph_tests.py
@@ -2,9 +2,9 @@
 
 """Grouping tests.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/tests/solph_tests.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/tests/solph_tests.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -
 
 """Tests of the component module.
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 from nose import tools
 from oemof import solph

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -2,9 +2,9 @@
 
 """Tests of the component module.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/tests/test_components.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/tests/test_components.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -2,8 +2,9 @@
 
 """Tests of the component module.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/tests/test_components.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -2,10 +2,12 @@
 
 """This module can be used to check the installation.
 This is not an illustrated example.
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 from oemof import solph
 import pandas as pd

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -3,8 +3,9 @@
 """This module can be used to check the installation.
 This is not an illustrated example.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/tests/test_installation.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -3,9 +3,9 @@
 """This module can be used to check the installation.
 This is not an illustrated example.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/tests/test_installation.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/tests/test_installation.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/test_network_classes.py
+++ b/tests/test_network_classes.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -
 
 """Test the created constraints against approved constraints.
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 from traceback import format_exception_only as feo
 from nose.tools import assert_raises, eq_, ok_

--- a/tests/test_network_classes.py
+++ b/tests/test_network_classes.py
@@ -2,8 +2,9 @@
 
 """Test the created constraints against approved constraints.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/tests/test_network_classes.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/test_network_classes.py
+++ b/tests/test_network_classes.py
@@ -2,9 +2,9 @@
 
 """Test the created constraints against approved constraints.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/tests/test_network_classes.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/tests/test_network_classes.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,6 +1,7 @@
 """
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/tests/test_processing.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,7 +1,7 @@
 """
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/tests/test_processing.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/tests/test_processing.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,3 +1,10 @@
+"""
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
 from nose.tools import ok_, eq_
 import pandas
 from oemof.solph import (

--- a/tests/test_scripts/test_solph/test_connect_invest/test_connect_invest.py
+++ b/tests/test_scripts/test_solph/test_connect_invest/test_connect_invest.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 
 """Connecting different investment variables.
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 from nose.tools import eq_
 import oemof.solph as solph

--- a/tests/test_scripts/test_solph/test_connect_invest/test_connect_invest.py
+++ b/tests/test_scripts/test_solph/test_connect_invest/test_connect_invest.py
@@ -2,8 +2,10 @@
 
 """Connecting different investment variables.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/tests/test_scripts/test_solph/
+test_connect_invest/test_connect_invest.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/test_scripts/test_solph/test_connect_invest/test_connect_invest.py
+++ b/tests/test_scripts/test_solph/test_connect_invest/test_connect_invest.py
@@ -2,10 +2,10 @@
 
 """Connecting different investment variables.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/tests/test_scripts/test_solph/
-test_connect_invest/test_connect_invest.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location 
+oemof/tests/test_scripts/test_solph/test_connect_invest/test_connect_invest.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/test_scripts/test_solph/test_flexible_modelling/test_add_constraints.py
+++ b/tests/test_scripts/test_solph/test_flexible_modelling/test_add_constraints.py
@@ -6,8 +6,10 @@ Model.
 The constraint we add forces a flow to be greater or equal a certain share
 of all inflows of its target bus. Moreover we will set an emission constraint.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/tests/test_scripts/test_solph/
+test_flexible_modelling/test_add_constraints.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/test_scripts/test_solph/test_flexible_modelling/test_add_constraints.py
+++ b/tests/test_scripts/test_solph/test_flexible_modelling/test_add_constraints.py
@@ -6,9 +6,9 @@ Model.
 The constraint we add forces a flow to be greater or equal a certain share
 of all inflows of its target bus. Moreover we will set an emission constraint.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/tests/test_scripts/test_solph/
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/tests/test_scripts/test_solph/
 test_flexible_modelling/test_add_constraints.py
 
 SPDX-License-Identifier: GPL-3.0-or-later

--- a/tests/test_scripts/test_solph/test_flexible_modelling/test_add_constraints.py
+++ b/tests/test_scripts/test_solph/test_flexible_modelling/test_add_constraints.py
@@ -5,10 +5,12 @@ This script shows how to a an individual constraint to the oemof solph
 Model.
 The constraint we add forces a flow to be greater or equal a certain share
 of all inflows of its target bus. Moreover we will set an emission constraint.
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 from nose.tools import ok_
 import logging

--- a/tests/test_scripts/test_solph/test_generic_caes/test_generic_caes.py
+++ b/tests/test_scripts/test_solph/test_generic_caes/test_generic_caes.py
@@ -3,9 +3,12 @@
 Example that illustrates how to use custom component `GenericCHP` can be used.
 
 In this case it is used to model a combined cycle extraction turbine.
+
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
 """
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
 
 from nose.tools import eq_
 import os

--- a/tests/test_scripts/test_solph/test_generic_caes/test_generic_caes.py
+++ b/tests/test_scripts/test_solph/test_generic_caes/test_generic_caes.py
@@ -4,8 +4,10 @@ Example that illustrates how to use custom component `GenericCHP` can be used.
 
 In this case it is used to model a combined cycle extraction turbine.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/tests/test_scripts/test_solph/
+test_generic_caes/test_generic_caes.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/test_scripts/test_solph/test_generic_caes/test_generic_caes.py
+++ b/tests/test_scripts/test_solph/test_generic_caes/test_generic_caes.py
@@ -4,10 +4,10 @@ Example that illustrates how to use custom component `GenericCHP` can be used.
 
 In this case it is used to model a combined cycle extraction turbine.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/tests/test_scripts/test_solph/
-test_generic_caes/test_generic_caes.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location 
+oemof/tests/test_scripts/test_solph/test_generic_caes/test_generic_caes.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/test_scripts/test_solph/test_generic_chp/test_generic_chp.py
+++ b/tests/test_scripts/test_solph/test_generic_chp/test_generic_chp.py
@@ -4,8 +4,10 @@ Example that illustrates how to use custom component `GenericCHP` can be used.
 
 In this case it is used to model a combined cycle extraction turbine.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/tests/test_scripts/test_solph/
+test_generic_chp/test_generic_chp.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/test_scripts/test_solph/test_generic_chp/test_generic_chp.py
+++ b/tests/test_scripts/test_solph/test_generic_chp/test_generic_chp.py
@@ -3,9 +3,12 @@
 Example that illustrates how to use custom component `GenericCHP` can be used.
 
 In this case it is used to model a combined cycle extraction turbine.
+
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
 """
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
 
 from nose.tools import eq_
 import os

--- a/tests/test_scripts/test_solph/test_generic_chp/test_generic_chp.py
+++ b/tests/test_scripts/test_solph/test_generic_chp/test_generic_chp.py
@@ -4,10 +4,10 @@ Example that illustrates how to use custom component `GenericCHP` can be used.
 
 In this case it is used to model a combined cycle extraction turbine.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/tests/test_scripts/test_solph/
-test_generic_chp/test_generic_chp.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location
+oemof/tests/test_scripts/test_solph/test_generic_chp/test_generic_chp.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/test_scripts/test_solph/test_generic_offsettransformer/test_generic_offsettransformer.py
+++ b/tests/test_scripts/test_solph/test_generic_offsettransformer/test_generic_offsettransformer.py
@@ -2,9 +2,9 @@
 """
 Example that shows how to use custom component `GenericOffsetTransformer`.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/tests/test_scripts/test_solph/
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/tests/test_scripts/test_solph/
 test_generic_offsettransformer/test_generic_offsettransformer.py
 
 SPDX-License-Identifier: GPL-3.0-or-later

--- a/tests/test_scripts/test_solph/test_generic_offsettransformer/test_generic_offsettransformer.py
+++ b/tests/test_scripts/test_solph/test_generic_offsettransformer/test_generic_offsettransformer.py
@@ -2,8 +2,10 @@
 """
 Example that shows how to use custom component `GenericOffsetTransformer`.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/tests/test_scripts/test_solph/
+test_generic_offsettransformer/test_generic_offsettransformer.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/test_scripts/test_solph/test_generic_offsettransformer/test_generic_offsettransformer.py
+++ b/tests/test_scripts/test_solph/test_generic_offsettransformer/test_generic_offsettransformer.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 """
 Example that shows how to use custom component `GenericOffsetTransformer`.
+
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
 """
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
 
 from nose.tools import eq_
 import os

--- a/tests/test_scripts/test_solph/test_simple_dispatch/test_simple_dispatch.py
+++ b/tests/test_scripts/test_solph/test_simple_dispatch/test_simple_dispatch.py
@@ -5,8 +5,10 @@ solve it with the solph module. Results are plotted with outputlib.
 
 Data: example_data.csv
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/tests/test_scripts/test_solph/
+test_simple_dispatch/test_simple_dispatch.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/test_scripts/test_solph/test_simple_dispatch/test_simple_dispatch.py
+++ b/tests/test_scripts/test_solph/test_simple_dispatch/test_simple_dispatch.py
@@ -4,10 +4,12 @@
 solve it with the solph module. Results are plotted with outputlib.
 
 Data: example_data.csv
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 from nose.tools import eq_
 import os

--- a/tests/test_scripts/test_solph/test_simple_dispatch/test_simple_dispatch.py
+++ b/tests/test_scripts/test_solph/test_simple_dispatch/test_simple_dispatch.py
@@ -5,10 +5,10 @@ solve it with the solph module. Results are plotted with outputlib.
 
 Data: example_data.csv
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/tests/test_scripts/test_solph/
-test_simple_dispatch/test_simple_dispatch.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location
+oemof/tests/test_scripts/test_solph/test_simple_dispatch/test_simple_dispatch.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/test_scripts/test_solph/test_storage_investment/test_storage_investment.py
+++ b/tests/test_scripts/test_solph/test_storage_investment/test_storage_investment.py
@@ -25,10 +25,12 @@ The example models the following energy system:
                      |------------------>|       |
 
 
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 from nose.tools import eq_
 from oemof.tools import economics

--- a/tests/test_scripts/test_solph/test_storage_investment/test_storage_investment.py
+++ b/tests/test_scripts/test_solph/test_storage_investment/test_storage_investment.py
@@ -26,8 +26,10 @@ The example models the following energy system:
 
 
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/tests/test_scripts/test_solph/
+test_storage_investment/test_storage_investment.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/test_scripts/test_solph/test_storage_investment/test_storage_investment.py
+++ b/tests/test_scripts/test_solph/test_storage_investment/test_storage_investment.py
@@ -26,9 +26,9 @@ The example models the following energy system:
 
 
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/tests/test_scripts/test_solph/
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/tests/test_scripts/test_solph/
 test_storage_investment/test_storage_investment.py
 
 SPDX-License-Identifier: GPL-3.0-or-later

--- a/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
+++ b/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
@@ -3,10 +3,12 @@
 """
 This test contains a ExtractionTurbineCHP class.
 
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 from nose.tools import eq_
 import logging

--- a/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
+++ b/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
@@ -4,10 +4,10 @@
 This test contains a ExtractionTurbineCHP class.
 
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/tests/test_scripts/test_solph/
-test_variable_chp/test_variable_chp.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location
+oemof/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
+++ b/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
@@ -4,8 +4,10 @@
 This test contains a ExtractionTurbineCHP class.
 
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/tests/test_scripts/test_solph/
+test_variable_chp/test_variable_chp.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/test_solph_network_classes.py
+++ b/tests/test_solph_network_classes.py
@@ -2,8 +2,9 @@
 
 """Test the created constraints against approved constraints.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/tests/test_solph_network_classes.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/test_solph_network_classes.py
+++ b/tests/test_solph_network_classes.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -
 
 """Test the created constraints against approved constraints.
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 from oemof import solph
 from nose.tools import assert_raises, eq_, ok_

--- a/tests/test_solph_network_classes.py
+++ b/tests/test_solph_network_classes.py
@@ -2,9 +2,9 @@
 
 """Test the created constraints against approved constraints.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/tests/test_solph_network_classes.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/tests/test_solph_network_classes.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/tool_tests.py
+++ b/tests/tool_tests.py
@@ -2,9 +2,9 @@
 
 """Test the created constraints against approved constraints.
 
-This file is part of project oemof. It's copyrighted by the contributors
-recorded in the version control history of the file, available from its original
-location https://github.com/oemof/tests/tool_tests.py
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted by
+the contributors recorded in the version control history of the file, available
+from its original location oemof/tests/tool_tests.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """

--- a/tests/tool_tests.py
+++ b/tests/tool_tests.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -
 
 """Test the created constraints against approved constraints.
-"""
 
-__copyright__ = "oemof developer group"
-__license__ = "GPLv3"
+Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
+                        Uwe Krien
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 import os
 

--- a/tests/tool_tests.py
+++ b/tests/tool_tests.py
@@ -2,8 +2,9 @@
 
 """Test the created constraints against approved constraints.
 
-Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
-                        Uwe Krien
+This file is part of project oemof. It's copyrighted by the contributors
+recorded in the version control history of the file, available from its original
+location https://github.com/oemof/tests/tool_tests.py
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """


### PR DESCRIPTION
According to #406 I changed the license file with find/replace. This leads to the same copyright in every file but that's all I will do to end this annoying topic.

Feel free to change it for individual files (add your name or remove a name), but remove names with care.

```python
"""
This module is about something....

Copyright (c) 2014-2018 Cord Kaldemeyer, Simon Hilpert, Stefan Günther,
                        Uwe Krien

SPDX-License-Identifier: GPL-3.0-or-later
"""
```
