### PR TITLE
Features/add min max runtimes

### DIFF
--- a/doc/whatsnew/v0-2-1.rst
+++ b/doc/whatsnew/v0-2-1.rst
@@ -10,6 +10,9 @@ API changes
 New features
 ############
 
+* It is now possible determine minimum up and downtimes for nonconvex flows.
+  Check the `oemof_examples <https://github.com/oemof/oemof_examples>`_
+  repository for an exemplary usage.
 
 
 New components
@@ -32,7 +35,8 @@ Known issues
 Bug fixes
 #########
 
-
+* Shutdown costs for nonconvex flows are now accounted within the objective
+  which was not the case before due to a naming error
 
 Testing
 #######

--- a/oemof/graph.py
+++ b/oemof/graph.py
@@ -37,8 +37,7 @@ def create_nx_graph(energy_system=None, optimization_model=None,
     --------
     >>> import os
     >>> import pandas as pd
-    >>> from oemof.solph import (Bus, Sink, Transformer, Flow, EnergySystem,
-    ...                          Model)
+    >>> from oemof.solph import (Bus, Sink, Transformer, Flow, EnergySystem)
     >>> import oemof.graph as grph
     >>> datetimeindex = pd.date_range('1/1/2017', periods=3, freq='H')
     >>> es = EnergySystem(timeindex=datetimeindex)

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -760,8 +760,8 @@ class NonConvexFlow(SimpleBlock):
                 expr += ((self.status[i, o, t-1]-self.status[i, o, t]) *
                          m.flows[i, o].nonconvex.minimum_downtime)
                 expr += - m.flows[i, o].nonconvex.minimum_downtime
-                expr += -sum(self.status[i, o, t+d] for d in range(0,
-                             m.flows[i, o].nonconvex.minimum_downtime))
+                expr += sum(self.status[i, o, t+d] for d in range(0,
+                            m.flows[i, o].nonconvex.minimum_downtime))
                 return expr <= 0
             else:
                 expr = 0

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -723,7 +723,8 @@ class NonConvexFlow(SimpleBlock):
         def _min_uptime_rule(block, i, o, t):
             """Rule definition for min-uptime constraints of nonconvex flows.
             """
-            if (t >= m.flows[i, o].nonconvex.max_up_down and t <= m.TIMESTEPS[-1]-m.flows[i, o].nonconvex.max_up_down):
+            if (t >= m.flows[i, o].nonconvex.max_up_down and
+                    t <= m.TIMESTEPS[-1]-m.flows[i, o].nonconvex.max_up_down):
                 expr = 0
                 expr += ((self.status[i, o, t]-self.status[i, o, t-1]) *
                          m.flows[i, o].nonconvex.minimum_uptime)
@@ -741,7 +742,8 @@ class NonConvexFlow(SimpleBlock):
         def _min_downtime_rule(block, i, o, t):
             """Rule definition for min-downtime constraints of nonconvex flows.
             """
-            if (t >= m.flows[i, o].nonconvex.max_up_down and t <= m.TIMESTEPS[-1]-m.flows[i, o].nonconvex.max_up_down):
+            if (t >= m.flows[i, o].nonconvex.max_up_down and
+                    t <= m.TIMESTEPS[-1]-m.flows[i, o].nonconvex.max_up_down):
                 expr = 0
                 expr += ((self.status[i, o, t-1]-self.status[i, o, t]) *
                          m.flows[i, o].nonconvex.minimum_downtime)

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -781,14 +781,14 @@ class NonConvexFlow(SimpleBlock):
 
         if self.STARTUPFLOWS:
             startcosts += sum(self.startup[i, o, t] *
-                              m.flows[i, o].nonconvex.startup_costs
+                              m.flows[i, o].nonconvex.startup_costs[t]
                               for i, o in self.STARTUPFLOWS
                               for t in m.TIMESTEPS)
             self.startcosts = Expression(expr=startcosts)
 
         if self.SHUTDOWNFLOWS:
             shutdowncosts += sum(self.shutdown[i, o, t] *
-                                 m.flows[i, o].nonconvex.shutdown_costs
+                                 m.flows[i, o].nonconvex.shutdown_costs[t]
                                  for i, o in self.SHUTDOWNFLOWS
                                  for t in m.TIMESTEPS)
             self.shudowcosts = Expression(expr=shutdowncosts)

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -714,6 +714,24 @@ class NonConvexFlow(SimpleBlock):
         self.shutdown_constr = Constraint(self.SHUTDOWNFLOWS, m.TIMESTEPS,
                                           rule=_shutdown_rule)
 
+        def _min_uptime_rule(block, i, o, t):
+            """Rule definition for min-uptime constraints of nonconvex flows.
+            """
+            # set initial status = end status
+            if t > m.TIMESTEPS[1] and t <= m.TIMESTEPS[-1]-3:
+                # m.flows[i, o].nonconvex.minimum_uptime
+                expr = ((self.status[i, o, t]-self.status[i, o, t-1]) *
+                        3 <= self.status[i, o, t] + self.status[i, o, t+1]
+                        + self.status[i, o, t+2])
+            else:
+                expr = Constraint.Skip
+                # expr = ((self.status[i, o, t]-self.status[i, o, t-1]) *
+                #         3 <= self.status[i, o, t] + self.status[i, o, t+1]
+                #         + self.status[i, o, t+2])
+            return expr
+        self.min_uptime_constr = Constraint(self.NONCONVEX_FLOWS, m.TIMESTEPS,
+                                            rule=_min_uptime_rule)
+
         # TODO: Add gradient constraints for nonconvex block / flows
         # TODO: Add  min-up/min-downtime constraints
 

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -572,6 +572,14 @@ class NonConvexFlow(SimpleBlock):
         A subset of set NONCONVEX_FLOWS with the attribute
         :attr:`shutdown_costs` being not None.
 
+    MINUPTIMEFLOWS
+        A subset of set NONCONVEX_FLOWS with the attribute
+        :attr:`minimum_uptime` being not None.
+
+    MINDOWNTIMEFLOWS
+        A subset of set NONCONVEX_FLOWS with the attribute
+        :attr:`minimum_downtime` being not None.
+
     **The following variables are created:**
 
     Status variable (binary) :attr:`om.NonConvexFlow.status`:

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -657,6 +657,14 @@ class NonConvexFlow(SimpleBlock):
         self.SHUTDOWNFLOWS = Set(initialize=[(g[0], g[1]) for g in group
                                  if g[2].nonconvex.shutdown_costs is not None])
 
+        self.MINUPTIMEFLOWS = Set(initialize=[(g[0], g[1]) for g in group
+                                  if g[2].nonconvex.minimum_uptime
+                                  is not None])
+
+        self.MINDOWNTIMEFLOWS = Set(initialize=[(g[0], g[1]) for g in group
+                                    if g[2].nonconvex.minimum_downtime
+                                    is not None])
+
         # ################### VARIABLES AND CONSTRAINTS #######################
         self.status = Var(self.NONCONVEX_FLOWS, m.TIMESTEPS, within=Binary)
 
@@ -729,11 +737,10 @@ class NonConvexFlow(SimpleBlock):
                 #         3 <= self.status[i, o, t] + self.status[i, o, t+1]
                 #         + self.status[i, o, t+2])
             return expr
-        self.min_uptime_constr = Constraint(self.NONCONVEX_FLOWS, m.TIMESTEPS,
+        self.min_uptime_constr = Constraint(self.MINUPTIMEFLOWS, m.TIMESTEPS,
                                             rule=_min_uptime_rule)
 
         # TODO: Add gradient constraints for nonconvex block / flows
-        # TODO: Add  min-up/min-downtime constraints
 
     def _objective_expression(self):
         r"""Objective expression for nonconvex flows.

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -721,13 +721,14 @@ class NonConvexFlow(SimpleBlock):
             return expr
         self.shutdown_constr = Constraint(self.SHUTDOWNFLOWS, m.TIMESTEPS,
                                           rule=_shutdown_rule)
-        # calc max of min down/uptime for border regions for if/else parts
+
         def _min_uptime_rule(block, i, o, t):
             """Rule definition for min-uptime constraints of nonconvex flows.
             """
-            if (t >= m.TIMESTEPS[1]+m.flows[i, o].nonconvex.minimum_uptime
-               and
-               t <= m.TIMESTEPS[-1]-m.flows[i, o].nonconvex.minimum_uptime):
+            max_up_down = (
+                max(m.TIMESTEPS[1]+m.flows[i, o].nonconvex.minimum_uptime,
+                    m.TIMESTEPS[1]+m.flows[i, o].nonconvex.minimum_downtime))
+            if (t >= max_up_down and t <= m.TIMESTEPS[-1]-max_up_down):
                 expr = 0
                 expr += ((self.status[i, o, t]-self.status[i, o, t-1]) *
                          m.flows[i, o].nonconvex.minimum_uptime)
@@ -745,9 +746,10 @@ class NonConvexFlow(SimpleBlock):
         def _min_downtime_rule(block, i, o, t):
             """Rule definition for min-downtime constraints of nonconvex flows.
             """
-            if (t >= m.TIMESTEPS[1]+m.flows[i, o].nonconvex.minimum_downtime
-               and
-               t <= m.TIMESTEPS[-1]-m.flows[i, o].nonconvex.minimum_downtime):
+            max_up_down = (
+                max(m.TIMESTEPS[1]+m.flows[i, o].nonconvex.minimum_uptime,
+                    m.TIMESTEPS[1]+m.flows[i, o].nonconvex.minimum_downtime))
+            if (t >= max_up_down and t <= m.TIMESTEPS[-1]-max_up_down):
                 expr = 0
                 expr += ((self.status[i, o, t-1]-self.status[i, o, t]) *
                          m.flows[i, o].nonconvex.minimum_downtime)

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -726,7 +726,7 @@ class NonConvexFlow(SimpleBlock):
             """Rule definition for min-uptime constraints of nonconvex flows.
             """
             # set initial status = end status
-            if (t > m.TIMESTEPS[1] and
+            if (t >= m.TIMESTEPS[1]+m.flows[i, o].nonconvex.minimum_uptime and
                t <= m.TIMESTEPS[-1]-m.flows[i, o].nonconvex.minimum_uptime):
                 expr = ((self.status[i, o, t]-self.status[i, o, t-1]) *
                         m.flows[i, o].nonconvex.minimum_uptime <=
@@ -734,10 +734,10 @@ class NonConvexFlow(SimpleBlock):
                         range(0, m.flows[i, o].nonconvex.minimum_uptime))
                         )
             else:
-                expr = Constraint.Skip
-                # expr = ((self.status[i, o, t]-self.status[i, o, t-1]) *
-                #         3 <= self.status[i, o, t] + self.status[i, o, t+1]
-                #         + self.status[i, o, t+2])
+                expr = (
+                    self.status[i, o, t] ==
+                    m.flows[i, o].nonconvex.initial_status
+                    )
             return expr
         self.min_uptime_constr = Constraint(self.MINUPTIMEFLOWS, m.TIMESTEPS,
                                             rule=_min_uptime_rule)

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -615,6 +615,13 @@ class NonConvexFlow(SimpleBlock):
             \forall t \in \textrm{TIMESTEPS}, \\
             \forall (i, o) \in \textrm{SHUTDOWN\_FLOWS}.
 
+    Minimum uptime constraint :attr:`om.NonConvexFlow.uptime_constr[i,o,t]`
+        .. math::
+            (status(i, o, t)-status(i, o, t-1)) \cdot minimum\_uptime(i, o) \
+            \leq \sum_{n=0}^{minimum\_uptime} status(i,o,t+n) \\
+            \forall t \in \textrm{TIMESTEPS}, \\  # not element for inner!
+            \forall (i,o) \in \textrm{MINUPTIME\_FLOWS}.
+
     **The following parts of the objective function are created:**
 
     If :attr:`nonconvex.startup_costs` is set by the user:

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -617,10 +617,35 @@ class NonConvexFlow(SimpleBlock):
 
     Minimum uptime constraint :attr:`om.NonConvexFlow.uptime_constr[i,o,t]`
         .. math::
-            (status(i, o, t)-status(i, o, t-1)) \cdot minimum\_uptime(i, o) \
-            \leq \sum_{n=0}^{minimum\_uptime} status(i,o,t+n) \\
-            \forall t \in \textrm{TIMESTEPS}, \\  # not element for inner!
+            (status(i, o, t)-status(i, o, t-1)) \cdot minimum\_uptime(i, o) \\
+            \leq \sum_{n=0}^{minimum\_uptime-1} status(i,o,t+n) \\
+            \forall t \in \textrm{TIMESTEPS} | \\
+            t \neq \{0..minimum\_uptime\} \cup \
+            \{t\_max-minimum\_uptime..t\_max\} , \\
             \forall (i,o) \in \textrm{MINUPTIME\_FLOWS}.
+            \\ \\
+            status(i, o, t) = initial\_status(i, o) \\
+            \forall t \in \textrm{TIMESTEPS} | \\
+            t = \{0..minimum\_uptime\} \cup \
+            \{t\_max-minimum\_uptime..t\_max\} , \\
+            \forall (i,o) \in \textrm{MINUPTIME\_FLOWS}.
+
+    Minimum downtime constraint :attr:`om.NonConvexFlow.downtime_constr[i,o,t]`
+        .. math::
+            (status(i, o, t-1)-status(i, o, t)) \
+            \cdot minimum\_downtime(i, o) \\
+            \leq minimum\_downtime(i, o) \
+            - \sum_{n=0}^{minimum\_downtime-1} status(i,o,t+n) \\
+            \forall t \in \textrm{TIMESTEPS} | \\
+            t \neq \{0..minimum\_downtime\} \cup \
+            \{t\_max-minimum\_downtime..t\_max\} , \\
+            \forall (i,o) \in \textrm{MINDOWNTIME\_FLOWS}.
+            \\ \\
+            status(i, o, t) = initial\_status(i, o) \\
+            \forall t \in \textrm{TIMESTEPS} | \\
+            t = \{0..minimum\_downtime\} \cup \
+            \{t\_max-minimum\_downtime..t\_max\} , \\
+            \forall (i,o) \in \textrm{MINDOWNTIME\_FLOWS}.
 
     **The following parts of the objective function are created:**
 

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -659,10 +659,12 @@ class NonConvexFlow(SimpleBlock):
                                          if g[2].min[0] is not None])
 
         self.STARTUPFLOWS = Set(initialize=[(g[0], g[1]) for g in group
-                                if g[2].nonconvex.startup_costs is not None])
+                                if g[2].nonconvex.startup_costs[0]
+                                is not None])
 
         self.SHUTDOWNFLOWS = Set(initialize=[(g[0], g[1]) for g in group
-                                 if g[2].nonconvex.shutdown_costs is not None])
+                                 if g[2].nonconvex.shutdown_costs[0]
+                                 is not None])
 
         self.MINUPTIMEFLOWS = Set(initialize=[(g[0], g[1]) for g in group
                                   if g[2].nonconvex.minimum_uptime
@@ -782,21 +784,18 @@ class NonConvexFlow(SimpleBlock):
         if self.STARTUPFLOWS:
             for i, o in self.STARTUPFLOWS:
                 if (m.flows[i, o].nonconvex.startup_costs[0] is not None):
-                    for t in m.TIMESTEPS:
-                        startcosts += (
-                            self.startup[i, o, t] *
-                            m.timeincrement[t] *
-                            m.flows[i, o].nonconvex.startup_costs[t])
+                    startcosts += sum(self.startup[i, o, t] *
+                                      m.flows[i, o].nonconvex.startup_costs[t]
+                                      for t in m.TIMESTEPS)
             self.startcosts = Expression(expr=startcosts)
 
         if self.SHUTDOWNFLOWS:
             for i, o in self.SHUTDOWNFLOWS:
                 if (m.flows[i, o].nonconvex.shutdown_costs[0] is not None):
-                    for t in m.TIMESTEPS:
-                        shutdowncosts += (
-                            self.startup[i, o, t] *
-                            m.timeincrement[t] *
-                            m.flows[i, o].nonconvex.shutdown_costs[t])
+                    shutdowncosts += sum(
+                        self.shutdown[i, o, t] *
+                        m.flows[i, o].nonconvex.shutdown_costs[t]
+                        for t in m.TIMESTEPS)
             self.shutdowncosts = Expression(expr=shutdowncosts)
 
         return startcosts + shutdowncosts

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -726,11 +726,13 @@ class NonConvexFlow(SimpleBlock):
             """Rule definition for min-uptime constraints of nonconvex flows.
             """
             # set initial status = end status
-            if t > m.TIMESTEPS[1] and t <= m.TIMESTEPS[-1]-3:
-                # m.flows[i, o].nonconvex.minimum_uptime
+            if (t > m.TIMESTEPS[1] and
+               t <= m.TIMESTEPS[-1]-m.flows[i, o].nonconvex.minimum_uptime):
                 expr = ((self.status[i, o, t]-self.status[i, o, t-1]) *
-                        3 <= self.status[i, o, t] + self.status[i, o, t+1]
-                        + self.status[i, o, t+2])
+                        m.flows[i, o].nonconvex.minimum_uptime <=
+                        sum(self.status[i, o, t+u] for u in
+                        range(0, m.flows[i, o].nonconvex.minimum_uptime))
+                        )
             else:
                 expr = Constraint.Skip
                 # expr = ((self.status[i, o, t]-self.status[i, o, t-1]) *

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -780,17 +780,23 @@ class NonConvexFlow(SimpleBlock):
         shutdowncosts = 0
 
         if self.STARTUPFLOWS:
-            startcosts += sum(self.startup[i, o, t] *
-                              m.flows[i, o].nonconvex.startup_costs[t]
-                              for i, o in self.STARTUPFLOWS
-                              for t in m.TIMESTEPS)
+            for i, o in self.STARTUPFLOWS:
+                if (m.flows[i, o].nonconvex.startup_costs[0] is not None):
+                    for t in m.TIMESTEPS:
+                        startcosts += (
+                            self.startup[i, o, t] *
+                            m.timeincrement[t] *
+                            m.flows[i, o].nonconvex.startup_costs[t])
             self.startcosts = Expression(expr=startcosts)
 
         if self.SHUTDOWNFLOWS:
-            shutdowncosts += sum(self.shutdown[i, o, t] *
-                                 m.flows[i, o].nonconvex.shutdown_costs[t]
-                                 for i, o in self.SHUTDOWNFLOWS
-                                 for t in m.TIMESTEPS)
-            self.shudowcosts = Expression(expr=shutdowncosts)
+            for i, o in self.SHUTDOWNFLOWS:
+                if (m.flows[i, o].nonconvex.shutdown_costs[0] is not None):
+                    for t in m.TIMESTEPS:
+                        shutdowncosts += (
+                            self.startup[i, o, t] *
+                            m.timeincrement[t] *
+                            m.flows[i, o].nonconvex.shutdown_costs[t])
+            self.shutdowncosts = Expression(expr=shutdowncosts)
 
         return startcosts + shutdowncosts

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -669,11 +669,9 @@ class NonConvexFlow(SimpleBlock):
         self.status = Var(self.NONCONVEX_FLOWS, m.TIMESTEPS, within=Binary)
 
         if self.STARTUPFLOWS:
-            self.startup = Var(self.STARTUPFLOWS, m.TIMESTEPS,
-                               within=Binary)
+            self.startup = Var(self.STARTUPFLOWS, m.TIMESTEPS, within=Binary)
         if self.SHUTDOWNFLOWS:
-            self.shutdown = Var(self.SHUTDOWNFLOWS, m.TIMESTEPS,
-                                within=Binary)
+            self.shutdown = Var(self.SHUTDOWNFLOWS, m.TIMESTEPS, within=Binary)
 
         def _minimum_flow_rule(block, i, o, t):
             """Rule definition for MILP minimum flow constraints.
@@ -725,13 +723,7 @@ class NonConvexFlow(SimpleBlock):
         def _min_uptime_rule(block, i, o, t):
             """Rule definition for min-uptime constraints of nonconvex flows.
             """
-            if m.flows[i, o].nonconvex.minimum_downtime is not None:
-                max_up_down = (max(
-                    m.TIMESTEPS[1]+m.flows[i, o].nonconvex.minimum_uptime,
-                    m.TIMESTEPS[1]+m.flows[i, o].nonconvex.minimum_downtime))
-            else:
-                max_up_down = m.flows[i, o].nonconvex.minimum_uptime
-            if (t >= max_up_down and t <= m.TIMESTEPS[-1]-max_up_down):
+            if (t >= m.flows[i, o].nonconvex.max_up_down and t <= m.TIMESTEPS[-1]-m.flows[i, o].nonconvex.max_up_down):
                 expr = 0
                 expr += ((self.status[i, o, t]-self.status[i, o, t-1]) *
                          m.flows[i, o].nonconvex.minimum_uptime)
@@ -749,13 +741,7 @@ class NonConvexFlow(SimpleBlock):
         def _min_downtime_rule(block, i, o, t):
             """Rule definition for min-downtime constraints of nonconvex flows.
             """
-            if m.flows[i, o].nonconvex.minimum_uptime is not None:
-                max_up_down = (max(
-                    m.TIMESTEPS[1]+m.flows[i, o].nonconvex.minimum_uptime,
-                    m.TIMESTEPS[1]+m.flows[i, o].nonconvex.minimum_downtime))
-            else:
-                max_up_down = m.flows[i, o].nonconvex.minimum_downtime
-            if (t >= max_up_down and t <= m.TIMESTEPS[-1]-max_up_down):
+            if (t >= m.flows[i, o].nonconvex.max_up_down and t <= m.TIMESTEPS[-1]-m.flows[i, o].nonconvex.max_up_down):
                 expr = 0
                 expr += ((self.status[i, o, t-1]-self.status[i, o, t]) *
                          m.flows[i, o].nonconvex.minimum_downtime)

--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -591,7 +591,6 @@ class GenericCHP(network.Transformer):
         length = [len(a) for a in attrs if not isinstance(a, (int, float))]
         max_length = max(length)
 
-
         if all(len(a) == max_length for a in attrs):
             if max_length == 0:
                 max_length += 1  # increment dimension for scalars from 0 to 1

--- a/oemof/solph/options.py
+++ b/oemof/solph/options.py
@@ -8,6 +8,8 @@ from its original location oemof/oemof/solph/options.py
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
+from oemof.solph.plumbing import sequence
+
 
 class Investment:
     """
@@ -55,12 +57,15 @@ class NonConvex:
         six timesteps is defined in addition to a four timestep minimum uptime.
     """
     def __init__(self, **kwargs):
-        # super().__init__(self, **kwargs)
-        self.startup_costs = kwargs.get('startup_costs')
-        self.shutdown_costs = kwargs.get('shutdown_costs')
-        self.minimum_uptime = kwargs.get('minimum_uptime')
-        self.minimum_downtime = kwargs.get('minimum_downtime')
-        self.initial_status = kwargs.get('initial_status', 0)
+        scalars = ['minimum_uptime', 'minimum_downtime', 'initial_status']
+        sequences = ['startup_costs', 'shutdown_costs']
+        defaults = {'initial_status': 0}
+
+        for attribute in set(scalars + sequences + list(kwargs)):
+            value = kwargs.get(attribute, defaults.get(attribute))
+            setattr(self, attribute,
+                    sequence(value) if attribute in sequences else value)
+
         self._max_up_down = None
 
     def _calculate_max_up_down(self):

--- a/oemof/solph/options.py
+++ b/oemof/solph/options.py
@@ -61,3 +61,29 @@ class NonConvex:
         self.minimum_uptime = kwargs.get('minimum_uptime')
         self.minimum_downtime = kwargs.get('minimum_downtime')
         self.initial_status = kwargs.get('initial_status', 0)
+        self._max_up_down = None
+
+    def _calculate_max_up_down(self):
+        """
+        Calculate maximum of up and downtime for direct usage in constraints.
+
+        The maximum of both is used to set the initial status for this
+        number of timesteps within the edge regions.
+        """
+        if (self.minimum_uptime is not None and self.minimum_downtime is None):
+            max_up_down = self.minimum_uptime
+        elif (self.minimum_uptime is None and
+              self.minimum_downtime is not None):
+            max_up_down = self.minimum_downtime
+        else:
+            max_up_down = max(self.minimum_uptime, self.minimum_downtime)
+
+        self._max_up_down = max_up_down
+
+    @property
+    def max_up_down(self):
+        """Compute or return the _max_up_down attribute."""
+        if self._max_up_down is None:
+            self._calculate_max_up_down()
+
+        return self._max_up_down

--- a/oemof/solph/options.py
+++ b/oemof/solph/options.py
@@ -35,7 +35,7 @@ class NonConvex:
     startup_costs : numeric
         Costs associated with a start of the flow (representing a unit).
     shutdown_costs : numeric
-        Costs associated with the shutdown of the flow (representing a until).
+        Costs associated with the shutdown of the flow (representing a unit).
     minimum_uptime : numeric
         Minimum time that a flow must be greater then its minimum flow after
         startup.

--- a/oemof/solph/options.py
+++ b/oemof/solph/options.py
@@ -38,12 +38,21 @@ class NonConvex:
         Costs associated with the shutdown of the flow (representing a unit).
     minimum_uptime : numeric (1 or positive integer)
         Minimum time that a flow must be greater then its minimum flow after
-        startup.
+        startup. Be aware that minimum up and downtimes can contradict each
+        other and may lead to infeasible problems.
     minimum_downtime : numeric (1 or positive integer)
         Minimum time a flow is forced to zero after shutting down.
+        Be aware that minimum up and downtimes can contradict each
+        other and may to infeasible problems.
     initial_status : numeric (0 or 1)
         Integer value indicating the status of the flow in the first time step
-        (0 = off, 1 = on).
+        (0 = off, 1 = on). For minimum up and downtimes, the initial status
+        is set for the respective values in the edge regions e.g. if a
+        minimum uptime of four timesteps is defined, the initial status is
+        fixed for the four first and last timesteps of the optimization period.
+        If both, up and downtimes are defined, the initial status is set for
+        the maximum of both e.g. for six timesteps if a minimum downtime of
+        six timesteps is defined in addition to a four timestep minimum uptime.
     """
     def __init__(self, **kwargs):
         # super().__init__(self, **kwargs)

--- a/oemof/solph/options.py
+++ b/oemof/solph/options.py
@@ -36,10 +36,10 @@ class NonConvex:
         Costs associated with a start of the flow (representing a unit).
     shutdown_costs : numeric
         Costs associated with the shutdown of the flow (representing a unit).
-    minimum_uptime : numeric
+    minimum_uptime : numeric (1 or positive integer)
         Minimum time that a flow must be greater then its minimum flow after
         startup.
-    minimum_downtime : numeric
+    minimum_downtime : numeric (1 or positive integer)
         Minimum time a flow is forced to zero after shutting down.
     initial_status : numeric (0 or 1)
         Integer value indicating the status of the flow in the first time step

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name='oemof',
       install_requires=['dill',
                         'numpy >= 1.7.0',
                         'pandas >= 0.18.0',
-                        'pyomo >= 4.2.0, != 4.3.11377, <5.4',
+                        'pyomo >= 4.2.0, != 4.3.11377',
                         'networkx'],
       entry_points={
           'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name='oemof',
       install_requires=['dill',
                         'numpy >= 1.7.0',
                         'pandas >= 0.18.0',
-                        'pyomo >= 4.2.0, != 4.3.11377',
+                        'pyomo >= 4.2.0, != 4.3.11377, <5.4',
                         'networkx'],
       entry_points={
           'console_scripts': [

--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -46,6 +46,14 @@ class Constraint_Tests:
                            timeindex=self.energysystem.timeindex)
 
     def compare_lp_files(self, filename, ignored=None, my_om=None):
+        r"""Compare lp-files to check constraints generated within solph.
+
+        An lp-file is being generated automatically when the tests are
+        executed. Make sure that you create an empty file first and
+        transfer the content from the one that has been created automatically
+        into this one afterwards. Make sure that the content is being checked
+        carefully. Otherwise, errors are included within the code base.
+        """
         if my_om is None:
             om = self.get_om()
         else:

--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -51,8 +51,8 @@ class Constraint_Tests:
         An lp-file is being generated automatically when the tests are
         executed. Make sure that you create an empty file first and
         transfer the content from the one that has been created automatically
-        into this one afterwards. Make sure that the content is being checked
-        carefully. Otherwise, errors are included within the code base.
+        into this one afterwards. Please ensure that the content is being
+        checked carefully. Otherwise, errors are included within the code base.
         """
         if my_om is None:
             om = self.get_om()


### PR DESCRIPTION
This adds the possibility to add min and max runtimes for `solph.NonConvexFlows`.

See https://github.com/oemof/oemof_examples/pull/16 for two example usages!