### PR TITLE
Features/update contraints to new pyomo api

### DIFF
--- a/oemof/graph.py
+++ b/oemof/graph.py
@@ -110,7 +110,8 @@ def create_nx_graph(energy_system=None, optimization_model=None,
     # passed or undirected edge otherwise
     for n in energy_system.nodes:
         for i in n.inputs.keys():
-            weight = energy_system.flows()[(i, n)].nominal_value
+            weight = getattr(energy_system.flows()[(i, n)],
+                             'nominal_value', None)
             if weight is None:
                 grph.add_edge(i.label, n.label)
             else:

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -178,7 +178,7 @@ class Flow(SimpleBlock):
                     else:
                         pass  # return(Constraint.Skip)
         self.positive_gradient_constr = Constraint(
-            self.POSITIVE_GRADIENT_FLOWS, noruleinit=True)
+            self.POSITIVE_GRADIENT_FLOWS, m.TIMESTEPS, noruleinit=True)
         self.positive_gradient_build = BuildAction(
             rule=_positive_gradient_flow_rule)
 
@@ -195,7 +195,7 @@ class Flow(SimpleBlock):
                     else:
                         pass  # return(Constraint.Skip)
         self.negative_gradient_constr = Constraint(
-            self.NEGATIVE_GRADIENT_FLOWS, noruleinit=True)
+            self.NEGATIVE_GRADIENT_FLOWS, m.TIMESTEPS, noruleinit=True)
         self.negative_gradient_build = BuildAction(
             rule=_negative_gradient_flow_rule)
 
@@ -484,7 +484,7 @@ class Bus(SimpleBlock):
                     # no inflows no outflows yield: 0 == 0 which is True
                     if expr is not True:
                         block.balance.add((n, t), expr)
-        self.balance = Constraint(group, noruleinit=True)
+        self.balance = Constraint(group, m.TIMESTEPS, noruleinit=True)
         self.balance_build = BuildAction(rule=_busbalance_rule)
 
 
@@ -534,7 +534,13 @@ class Transformer(SimpleBlock):
         in_flows = {n: [i for i in n.inputs.keys()] for n in group}
         out_flows = {n: [o for o in n.outputs.keys()] for n in group}
 
-        self.relation = Constraint(group, noruleinit=True)
+
+        self.relation = Constraint(
+            [(n, i, o, t)
+             for t in m.TIMESTEPS
+             for n in group
+             for o in out_flows[n]
+             for i in in_flows[n]], noruleinit=True)
 
         def _input_output_relation(block):
             for t in m.TIMESTEPS:

--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -952,7 +952,8 @@ class ExtractionTurbineCHPBlock(SimpleBlock):
                         g.conversion_factor_full_condensation_sq[t]
                         )
                     block.input_output_relation.add((n, t), (lhs == rhs))
-        self.input_output_relation = Constraint(group, noruleinit=True)
+        self.input_output_relation = Constraint(group, m.TIMESTEPS,
+                                                noruleinit=True)
         self.input_output_relation_build = BuildAction(
             rule=_input_output_relation_rule)
 
@@ -965,7 +966,8 @@ class ExtractionTurbineCHPBlock(SimpleBlock):
                     rhs = (m.flow[g, g.tapped_output, t] *
                            g.flow_relation_index[t])
                     block.out_flow_relation.add((g, t), (lhs >= rhs))
-        self.out_flow_relation = Constraint(group, noruleinit=True)
+        self.out_flow_relation = Constraint(group, m.TIMESTEPS,
+                                            noruleinit=True)
         self.out_flow_relation_build = BuildAction(
                 rule=_out_flow_relation_rule)
 

--- a/tests/test_scripts/test_solph/test_storage_investment/test_storage_investment.py
+++ b/tests/test_scripts/test_solph/test_storage_investment/test_storage_investment.py
@@ -136,8 +136,8 @@ def test_optimise_storage_size(filename="storage_investment.csv", solver='cbc'):
     eq_(str(meta['solver']['Status']), 'ok')
 
     # Problem results
-    eq_(meta['problem']['Lower bound'], 4.2316758e+17)
-    eq_(meta['problem']['Upper bound'], 4.2316758e+17)
+    eq_(meta['problem']['Lower bound'], 4.231675777e+17)
+    eq_(meta['problem']['Upper bound'], 4.231675777e+17)
     eq_(meta['problem']['Number of variables'], 2804)
     eq_(meta['problem']['Number of constraints'], 2805)
     eq_(meta['problem']['Number of nonzeros'], 7606)


### PR DESCRIPTION
* Describe your pull request as transparent as possible
  * Adapt internal contraint creation to new pyomo api
  ...

* Related issues:
#448 

* Share your knowledge: Insights/Remarks
See commit message and discussion here:

https://groups.google.com/forum/#!topic/pyomo-forum/MQbSL2BOOG0

* Other comments and questions
There is still an open question as one result check 'fails', but this seems to be a numerical decimal precision issue, as far as I see it. I adpted the corresponding test.

I did not test with old pyomo version. Though I guess there should not be a problem. 

I think this might slow down contraint creation a little maybe only marginally. But I do not see an other way right now, as it is the standard way to deal with this problem. Speeding up oemof, is a different topic. For me this is ok right now. 
