### PR TITLE
Make deserialized nodes serializable again

### DIFF
--- a/doc/whatsnew/v0-2-1.rst
+++ b/doc/whatsnew/v0-2-1.rst
@@ -37,6 +37,14 @@ New features
     (`Issue #445 <https://github.com/oemof/oemof/issues/445>`_)
 
 
+Fixes
+#####
+
+  * Deserializing a :class:`Node <oemof.network.Node>` lead to an object which
+    was no longer serializable. This is fixed now. :class:`Node
+    <oemof.network.Node>` instances should be able to be dumped and restored an
+    arbitraty amount of times.
+
 Documentation
 #############
 

--- a/doc/whatsnew/v0-2-1.rst
+++ b/doc/whatsnew/v0-2-1.rst
@@ -70,11 +70,11 @@ Testing
 Other changes
 #############
 
-  * Internal change: Unnecessary list extensions while creating a model are avoided,
-    which leads to a decrease in runtime.
+  * Internal change: Unnecessary list extensions while creating a model are
+    avoided, which leads to a decrease in runtime.
     (`Issue #438 <https://github.com/oemof/oemof/issues/438>`_)
-  * The negative/positive gradient attributes are dictionaries. In the constructor
-    they moved from sequences to a new `dictionaries` argument.
+  * The negative/positive gradient attributes are dictionaries. In the
+    constructor they moved from sequences to a new `dictionaries` argument.
     (`Issue #437 <https://github.com/oemof/oemof/issues/437>`_)
   * License agreement was adapted according to the reuse project
     (`Issue #442 <https://github.com/oemof/oemof/issues/442>`_)

--- a/doc/whatsnew/v0-2-1.rst
+++ b/doc/whatsnew/v0-2-1.rst
@@ -40,10 +40,11 @@ New features
 Fixes
 #####
 
-  * Deserializing a :class:`Node <oemof.network.Node>` lead to an object which
+  * Deserializing a :class:`Node <oemof.network.Node>` leads to an object which
     was no longer serializable. This is fixed now. :class:`Node
     <oemof.network.Node>` instances should be able to be dumped and restored an
     arbitraty amount of times.
+
 
 Documentation
 #############
@@ -54,10 +55,11 @@ Documentation
 Known issues
 ############
 
-  * It is not possible to model one time step with oemof.solph. You have to model
-    at least two timesteps
+  * It is not possible to model one time step with oemof.solph. You have to
+    model at least two timesteps
     (`Issue #306 <https://github.com/oemof/oemof/issues/306>`_). Please leave a
     comment if this bug affects you.
+
 
 Bug fixes
 #########
@@ -69,11 +71,13 @@ Bug fixes
   * Adapt solph to API change in the Pyomo package.
     (`Issue #449 <https://github.com/oemof/oemof/issues/449>`_)
 
+
 Testing
 #######
 
   * New console script `test_oemof` has been added (experimental).
     (`Issue #453 <https://github.com/oemof/oemof/issues/453>`_)
+
 
 Other changes
 #############

--- a/doc/whatsnew/v0-2-1.rst
+++ b/doc/whatsnew/v0-2-1.rst
@@ -5,7 +5,7 @@ v0.2.1 (March 9, 2018)
 API changes
 ###########
 
-  * The function create_nx_graph only takes an energysystem as argument, 
+  * The function create_nx_graph only takes an energysystem as argument,
     not a solph model. As it is not a major release you can still pass
     a Model but you should adapt your application as soon as possible.
     (`Issue #439 <https://github.com/oemof/oemof/issues/439>`_)
@@ -17,22 +17,22 @@ New features
   * It is now possible determine minimum up and downtimes for nonconvex flows.
     Check the `oemof_examples <https://github.com/oemof/oemof_examples>`_
     repository for an exemplary usage.
-  
+
   * Startup and shutdown costs can now be defined time-dependent.
 
   * The graph module has been revised.
     (`Issue #439 <https://github.com/oemof/oemof/issues/439>`_)
-    
+
     * You can now store a graph to disc as `.graphml` file to open it in yEd
-      with labels. 
-    * You can add weight to edges.  
+      with labels.
+    * You can add weight to edges.
     * Labels are attached to the nodes.
-  
-  * Two functions `get_node_by_name` and `filter_nodes` have been added that 
+
+  * Two functions `get_node_by_name` and `filter_nodes` have been added that
     allow to get specified nodes or nodes of one kind from the results
     dictionary. (`Issue #426 <https://github.com/oemof/oemof/issues/426>`_)
-  
-  * A new function `param_results()` collects all parameters of nodes and flows 
+
+  * A new function `param_results()` collects all parameters of nodes and flows
     in a dictionary similar to the `results` dictionary.
     (`Issue #445 <https://github.com/oemof/oemof/issues/445>`_)
 
@@ -63,7 +63,7 @@ Bug fixes
 
 Testing
 #######
-  
+
   * New console script `test_oemof` has been added (experimental).
     (`Issue #453 <https://github.com/oemof/oemof/issues/453>`_)
 
@@ -80,7 +80,7 @@ Other changes
     (`Issue #442 <https://github.com/oemof/oemof/issues/442>`_)
   * Code of conduct was added.
     (`Issue #440 <https://github.com/oemof/oemof/issues/440>`_)
-  
+
 
 Contributors
 ############

--- a/oemof/network.py
+++ b/oemof/network.py
@@ -196,8 +196,7 @@ class Node:
     __slots__ = ["__weakref__", "_label", "_inputs", "_state"]
 
     def __init__(self, *args, **kwargs):
-        self._state = (args, kwargs)
-        self.__setstate__(self._state)
+        self.__setstate__((args, kwargs))
         if __class__.registry is not None:
             __class__.registry.add(self)
 
@@ -205,6 +204,7 @@ class Node:
         return self._state
 
     def __setstate__(self, state):
+        self._state = state
         args, kwargs = state
         for optional in ['label']:
             if optional in kwargs:

--- a/oemof/solph/custom.py
+++ b/oemof/solph/custom.py
@@ -788,7 +788,7 @@ def custom_component_grouping(node):
         return ElectricalLineBlock
     if isinstance(node, GenericCAES):
         return GenericCAESBlock
-    if type(node) is Link:
+    if isinstance(node, Link):
         return LinkBlock
     if isinstance(node, OffsetTransformer):
         return OffsetTransformerBlock


### PR DESCRIPTION
@ckaldemeyer discovered a bug which meant that `Node`s could not be dumped again after being restored. He discovered this by using `copy.deepcopy` which uses the same protocol as dumping/restoring via `pickle`.
I fixed the issue and would like to have the fix in the next release.
@ckaldemeyer  also made an [example](https://github.com/oemof/oemof_examples/blob/5c120d70f326d8784e7395d22011ea72d5659df0/examples/oemof_0.2/generic_chp/bpt.py) which gets fixed by this branch, so I know my fix works.