### PR TITLE
limit version of required packages to the most actual version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,12 +29,12 @@ setup(name='oemof',
       packages=find_packages(),
       package_data={'oemof': [
           os.path.join('tools', 'default_files', '*.ini')]},
-      install_requires=['dill',
-                        'numpy >= 1.7.0',
-                        'pandas >= 0.18.0',
-                        'pyomo >= 4.2.0, != 4.3.11377',
-                        'networkx',
-                        'nose'],
+      install_requires=['dill <= 0.2.7.1',
+                        'numpy >= 1.7.0, <= 1.14.2',
+                        'pandas >= 0.18.0, <= 0.22',
+                        'pyomo >= 4.2.0, <= 5.4.3',
+                        'networkx <= 2.1',
+                        'nose <= 1.3.7'],
       entry_points={
           'console_scripts': [
               'oemof_installation_test = '

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(name='oemof',
       install_requires=['dill <= 0.2.7.1',
                         'numpy >= 1.7.0, <= 1.14.2',
                         'pandas >= 0.18.0, <= 0.22',
-                        'pyomo >= 4.2.0, <= 5.4.3',
+                        'pyomo >= 4.4.0, <= 5.4.3',
                         'networkx <= 2.1',
                         'nose <= 1.3.7'],
       entry_points={


### PR DESCRIPTION
This PR will limit the version of each required package in the setup.py to the most actual (working) version for the v0.2.1 release.

The reason is that otherwise pip install oemof will always install the most actual version of each package at the moment of the installation. This behaviour may lead to errors (see #464) if the the API of one required package changed since the last oemof release.

You may check the versions right before the release if I missed an actual important update.