### PR TITLE
Decouple the investment of storage flows and capacity

### DIFF
--- a/doc/whatsnew/v0-2-2.rst
+++ b/doc/whatsnew/v0-2-2.rst
@@ -10,7 +10,11 @@ API changes
 New features
 ############
 
-
+* Investement variables for the capacity and the flows are now decoupled to
+enable more flexibility. It is possible to couple the flows to the capacity,
+the flows to itself or to not couple anything. Added attribute: 
+'invest_relation_input_output_power'. Scalar that indicates the input power ratio 
+compared to the output power ratio. 
 
 New components
 ##############
@@ -45,3 +49,4 @@ Contributors
 ############
 
 * Uwe Krien
+* Fabian Büllesbach

--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -134,7 +134,7 @@ class GenericStorage(network.Transformer):
         self.capacity_min = solph_sequence(kwargs.get('capacity_min', 0))
         self.investment = kwargs.get('investment')
         self.invest_relation_input_output_power = kwargs.get('invest_relation_input_output_power',None)
-        self.cyclic = kwargs.get('cyclic', None)
+        self.cyclic = kwargs.get('cyclic', True)
 
         # General error messages
         self._e_no_nv = (
@@ -408,7 +408,7 @@ class GenericInvestmentStorageBlock(SimpleBlock):
                 n for n in group if n.invest_relation_input_output_power is not None])
 
         self.INITIAL_CAPACITY = Set(initialize=[
-                n for n in group if n.initial_capacity is not None and n.cyclic is None])
+                n for n in group if n.initial_capacity is not None and n.cyclic is True])
 
         # The capacity is set as a non-negative variable, therefore it makes no
         # sense to create an additional constraint if the lower bound is zero

--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -375,6 +375,8 @@ class GenericInvestmentStorageBlock(SimpleBlock):
         # ########################## SETS #####################################
 
         self.INVESTSTORAGES = Set(initialize=[n for n in group])
+        self.INVESTSTORAGESINPUT = Set(initialize=[n for n in group if n.nominal_input_capacity_ratio is not None])
+        self.INVESTSTORAGESOUTPUT = Set(initialize=[n for n in group if n.nominal_output_capacity_ratio is not None])
 
         self.INITIAL_CAPACITY = Set(initialize=[
             n for n in group if n.initial_capacity is not None])
@@ -431,26 +433,22 @@ class GenericInvestmentStorageBlock(SimpleBlock):
             `InvestmentFlow.invest of storage with invested capacity `invest`
             by nominal_capacity__inflow_ratio
             """
-            if n.nominal_input_capacity_ratio is not None:
-              expr = (m.InvestmentFlow.invest[i[n], n] ==
-                     self.invest[n] * n.nominal_input_capacity_ratio)
-              return expr
-            return Constraint.Skip
+            expr = (m.InvestmentFlow.invest[i[n], n] ==
+                    self.invest[n] * n.nominal_input_capacity_ratio)
+            return expr          
         self.storage_capacity_inflow = Constraint(
-            self.INVESTSTORAGES, rule=_storage_capacity_inflow_invest_rule)
+            self.INVESTSTORAGESINPUT, rule=_storage_capacity_inflow_invest_rule)
 
         def _storage_capacity_outflow_invest_rule(block, n):
             """Rule definition of constraint connecting outflow
             `InvestmentFlow.invest` of storage and invested capacity `invest`
             by nominal_capacity__outflow_ratio
             """
-            if n.nominal_output_capacity_ratio is not None:
-             expr = (m.InvestmentFlow.invest[n, o[n]] ==
-                     self.invest[n] * n.nominal_output_capacity_ratio)
-              return expr
-            return Constraint.Skip
+            expr = (m.InvestmentFlow.invest[n, o[n]] ==
+                    self.invest[n] * n.nominal_output_capacity_ratio)
+            return expr
         self.storage_capacity_outflow = Constraint(
-            self.INVESTSTORAGES, rule=_storage_capacity_outflow_invest_rule)
+            self.INVESTSTORAGESOUTPUT, rule=_storage_capacity_outflow_invest_rule)
 
         def _max_capacity_invest_rule(block, n, t):
             """Rule definition for upper bound constraint for the storage cap.

--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -431,9 +431,11 @@ class GenericInvestmentStorageBlock(SimpleBlock):
             `InvestmentFlow.invest of storage with invested capacity `invest`
             by nominal_capacity__inflow_ratio
             """
-            expr = (m.InvestmentFlow.invest[i[n], n] ==
-                    self.invest[n] * n.nominal_input_capacity_ratio)
-            return expr
+            if n.nominal_input_capacity_ratio is not None:
+              expr = (m.InvestmentFlow.invest[i[n], n] ==
+                     self.invest[n] * n.nominal_input_capacity_ratio)
+              return expr
+            return Constraint.Skip
         self.storage_capacity_inflow = Constraint(
             self.INVESTSTORAGES, rule=_storage_capacity_inflow_invest_rule)
 
@@ -442,9 +444,11 @@ class GenericInvestmentStorageBlock(SimpleBlock):
             `InvestmentFlow.invest` of storage and invested capacity `invest`
             by nominal_capacity__outflow_ratio
             """
-            expr = (m.InvestmentFlow.invest[n, o[n]] ==
-                    self.invest[n] * n.nominal_output_capacity_ratio)
-            return expr
+            if n.nominal_output_capacity_ratio is not None:
+             expr = (m.InvestmentFlow.invest[n, o[n]] ==
+                     self.invest[n] * n.nominal_output_capacity_ratio)
+              return expr
+            return Constraint.Skip
         self.storage_capacity_outflow = Constraint(
             self.INVESTSTORAGES, rule=_storage_capacity_outflow_invest_rule)
 

--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -130,7 +130,7 @@ class GenericStorage(network.Transformer):
         self.capacity_min = solph_sequence(kwargs.get('capacity_min', 0))
         self.investment = kwargs.get('investment')
         self.couple_investment = kwargs.get('couple_investment', None)
-        self.cyclic = kwargs.get('cyclic',None)
+        self.cyclic = kwargs.get('cyclic', None)
 
         # General error messages
         self._e_no_nv = (


### PR DESCRIPTION
The old GenericInvestmentStorageBlock had a fixed Capacity Ratio that had to be initialized and thus you could not solely let oemof invest into the Input/Output Flow.

By adding the if-Statements, it is now possible to have a storage flow that does not influence the capacity of the storage.