### PR TITLE
Add option for objective function timestep  weighting indepent of con…

### DIFF
--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -219,7 +219,7 @@ class Flow(SimpleBlock):
         for i, o in m.FLOWS:
             if m.flows[i, o].variable_costs[0] is not None:
                 for t in m.TIMESTEPS:
-                    variable_costs += (m.flow[i, o, t] * m.timeincrement[t] *
+                    variable_costs += (m.flow[i, o, t] * m.objective_weighting[t] *
                                        m.flows[i, o].variable_costs[t])
 
             if m.flows[i, o].positive_gradient['ub'][0] is not None:

--- a/oemof/solph/models.py
+++ b/oemof/solph/models.py
@@ -49,6 +49,9 @@ class BaseModel(po.ConcreteModel):
 
         self.timeincrement = sequence(self.es.timeindex.freq.nanos / 3.6e12)
 
+        self.objective_weighting = kwargs.get('objective_weighting',
+                                              self.timeincrement)
+
         self._constraint_groups = (type(self).CONSTRAINT_GROUPS +
                                    kwargs.get('constraint_groups', []))
 

--- a/oemof/solph/models.py
+++ b/oemof/solph/models.py
@@ -28,6 +28,10 @@ class BaseModel(po.ConcreteModel):
         Solph looks for these groups in the given energy system and uses them
         to create the constraints of the optimization problem.
         Defaults to :const:`Model.CONSTRAINTS`
+    objective_weighting : array like (optional)
+        Weights used for temporal objective function
+        expressions. If nothing is passed `timeincrement` will be used which 
+        is calculated from the freq length of the energy system timeindex .
     auto_construct : boolean
         If this value is true, the set, variables, constraints, etc. are added,
         automatically when instantiating the model. For sequential model


### PR DESCRIPTION


**Description**
 * Add possiblity to only set weighting for objective function expressions (independent of constraints)
 * For example useful for temporal aggregation where only economic weighting is wanted 
 
Just pass an array.
```
Model(es, objective_weighting=[10, 10, ...])
```

If kw is not passed, the time increment will be used. Therefore, nothing changes for users.