### PR TITLE
move not working console script to test

### DIFF
--- a/nose.cfg
+++ b/nose.cfg
@@ -1,4 +1,3 @@
 [nosetests]
 with-coverage=1
 cover-package=oemof
-cover-erase=1

--- a/oemof/tools/console_scripts.py
+++ b/oemof/tools/console_scripts.py
@@ -59,18 +59,3 @@ def check_oemof_installation(silent=False):
         print("*****************************")
         print("oemof successfully installed.")
         print("*****************************")
-
-
-def test_oemof():
-    """Experimental function. No guarantee but nice if it works :-) """
-    testdir = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
-    argv = sys.argv[:]
-    argv.insert(1, "--with-doctest")
-    argv.insert(1, "--logging-clear-handlers")
-    argv.insert(1, "-w{0}".format(testdir))
-    nose.run(argv=argv)
-
-
-if __name__ == "__main__":
-    check_oemof_installation(silent=False)
-    # check_nosetests()

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,6 @@ setup(name='oemof',
       namespace_package=['oemof'],
       long_description=read('README.rst'),
       packages=find_packages(),
-      package_data={'oemof': [
-          os.path.join('tools', 'default_files', '*.ini')]},
       install_requires=['dill <= 0.2.7.1',
                         'numpy >= 1.7.0, <= 1.14.2',
                         'pandas >= 0.18.0, <= 0.23',

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,7 @@ setup(name='oemof',
                         'numpy >= 1.7.0, <= 1.14.2',
                         'pandas >= 0.18.0, <= 0.23',
                         'pyomo >= 4.4.0, <= 5.4.3',
-                        'networkx <= 2.1',
-                        'nose <= 1.3.7'],
+                        'networkx <= 2.1'],
       extras_require={'datapackage': ['datapackage']},
       entry_points={
           'console_scripts': [

--- a/tests/run_nose.py
+++ b/tests/run_nose.py
@@ -1,0 +1,23 @@
+import sys
+import os
+
+try:
+    import nose
+except ImportError:
+    raise ImportError("Please install nosetest to use this script.")
+
+
+def nose_oemof():
+    """You can just execute this function to run the oemof nosetests and
+    doctests. Nosetests has to be installed.
+    """
+    testdir = os.path.join(os.path.dirname(__file__), os.path.pardir)
+    argv = sys.argv[:]
+    argv.insert(1, "--with-doctest")
+    argv.insert(1, "--logging-clear-handlers")
+    argv.insert(1, "-w{0}".format(testdir))
+    nose.run(argv=argv)
+
+
+if __name__ == "__main__":
+    nose_oemof()

--- a/tests/test_console_scripts.py
+++ b/tests/test_console_scripts.py
@@ -12,5 +12,5 @@ import oemof.tools.console_scripts as console_scripts
 
 
 def test_console_scripts():
-    console_scripts.check_oemof_installation(silent=True)
+    console_scripts.check_oemof_installation(silent=False)
     pass


### PR DESCRIPTION
It does not work if oemof is installed via pip.
Now it can be executed via IDE or console using the python command.

In my opinion this is cleaner. You do not have to use it anyway but it contains all needed parameter.