### PR TITLE
make it possible to get version/commit/branch without using the logger

### DIFF
--- a/oemof/tools/logger.py
+++ b/oemof/tools/logger.py
@@ -75,9 +75,8 @@ def define_logging(logpath=None, logfile='oemof.log', file_format=None,
     >>> from oemof.tools import logger
     >>> mypath = logger.define_logging(
     ...     log_path=True, log_version=True, timed_rotating={'backupCount': 4},
-    ...     screen_datefmt = "no_date")  # doctest: +ELLIPSIS
-    no_date-INFO-Path for logging: ...
-    no_date-INFO-Used oemof version: ...
+    ...     screen_level=logging.ERROR, screen_datefmt = "no_date"
+    ...     )  # doctest: +ELLIPSIS
     >>> mypath[-9:]
     'oemof.log'
     >>> logging.debug("Hallo")

--- a/oemof/tools/logger.py
+++ b/oemof/tools/logger.py
@@ -75,8 +75,7 @@ def define_logging(logpath=None, logfile='oemof.log', file_format=None,
     >>> from oemof.tools import logger
     >>> mypath = logger.define_logging(
     ...     log_path=True, log_version=True, timed_rotating={'backupCount': 4},
-    ...     screen_level=logging.ERROR, screen_datefmt = "no_date"
-    ...     )  # doctest: +ELLIPSIS
+    ...     screen_level=logging.ERROR, screen_datefmt = "no_date")
     >>> mypath[-9:]
     'oemof.log'
     >>> logging.debug("Hallo")

--- a/oemof/tools/logger.py
+++ b/oemof/tools/logger.py
@@ -14,6 +14,7 @@ import logging
 from logging import handlers
 import sys
 from oemof.tools import helpers
+import oemof
 
 
 def define_logging(logpath=None, logfile='oemof.log', file_format=None,
@@ -158,7 +159,6 @@ def check_version():
     >>> int(v.split('.')[0])
     0
     """
-    import oemof
     try:
         version = oemof.__version__
     except AttributeError:
@@ -170,7 +170,10 @@ def check_git_branch():
     """Passes the used branch and commit to the logger
 
     >>> from oemof.tools import logger
-    >>> v = logger.check_git_branch()
+    >>> try:
+    ...    v = logger.check_git_branch()
+    ... except FileNotFoundError:
+    ...    v = ('abcdefgh', 'branch')
     >>> type(v)
     <class 'tuple'>
     >>> type(v[0])


### PR DESCRIPTION
It looks more complicated than it is. I just needed to get the version regardless of the logger. Therefore, I unbundled the functions a little bit. I need this feature, so I would appreciate I quick review.