### PR TITLE
Documentation/improve storage docs

### DIFF
--- a/doc/oemof_solph.rst
+++ b/doc/oemof_solph.rst
@@ -445,9 +445,9 @@ As an addition to other flow-investments, the storage class implements the possi
 with the capacity of the storage. 
 Three parameters are responsible for connecting the flows and the capacity of the storage:
 
-    *	`invest_relation_input_capacity` fixes the inflow to the capacity. A ratio of ‘1’ means that the storage can be emptied within one time-period. 
-    *	`invest_relation_output_capacity` fixes the outflow to the capacity. A ratio of ‘1’ means that the storage can be emptied within one period.
-    *	`invest_relation_input_output` fixes the input flow to the output flow. For values <1, the input will be smaller and for values >1 the input flow will be larger. 
+    *	' `invest_relation_input_capacity` ' fixes the inflow to the capacity. A ratio of ‘1’ means that the storage can be emptied within one time-period. 
+    *	' `invest_relation_output_capacity` ' fixes the outflow to the capacity. A ratio of ‘1’ means that the storage can be emptied within one period.
+    *	' `invest_relation_input_output` ' fixes the input flow to the output flow. For values <1, the input will be smaller and for values >1 the input flow will be larger. 
     
 Not all 3 parameters can be set at the same time. 
 The optimization problem will then determine the optimal capacity as well as the optimal flows.

--- a/doc/oemof_solph.rst
+++ b/doc/oemof_solph.rst
@@ -451,40 +451,34 @@ Three parameters are responsible for connecting the flows and the capacity of th
     *	' `invest_relation_output_capacity` ' fixes the output flow investment to the capacity investment. A ratio of ‘1’ means that the storage can be emptied within one period.
     *	' `invest_relation_input_output` ' fixes the input flow investment to the output flow investment. For values <1, the input will be smaller and for values >1 the input flow will be larger. 
     
-You should not set all 3 parameters at the same time, since it will lead to overditermination
-This following example-storage is not usable. The input flow has to be 1/6 of the capacity whereas the output has to be equal to the capacity and additionally both flows shall be equal.
+You should not set all 3 parameters at the same time, since it will lead to overditermination.
+
+This following example-storage pictures a PHES. Both flows and the storage itself (representing: pump, turbine, basin) are free in their investment. You can set the parameters to `None` or delete them as `None` is the default value.   
 
 .. code-block:: python
 
     solph.GenericStorage(
-        label='storage',
-        inputs={b_el: solph.Flow(investment= solph.Investment(ep_costs=100))},
-        outputs={b_el: solph.Flow(investment= solph.Investment(ep_costs=100)},
+        label='PHES',
+        inputs={b_el: solph.Flow(investment= solph.Investment(ep_costs=500))},
+        outputs={b_el: solph.Flow(investment= solph.Investment(ep_costs=500)},
         capacity_loss=0.001, 
         inflow_conversion_factor=0.98, outflow_conversion_factor=0.8),
-        invest_relation_input_output = 1
-        invest_relation_input_capacity = 1, invest_relation_output_capacity = 1/6,
-        investment = solph.Investment(ep_costs=50) 
+        investment = solph.Investment(ep_costs=40) 
 
-Instead you should use the storage as follows (one example).
+The following example describes a battery where we have coupled the flows (representing power) to the capacity of the storage.
 
 .. code-block:: python
 
     solph.GenericStorage(
-        label='storage',
-        inputs={b_el: solph.Flow(investment= solph.Investment(ep_costs=100, existing = 20000, 
-                                                              maximum = 30000))},
-        outputs={b_el: solph.Flow(investment= solph.Investment(ep_costs=100, existing = 20000, 
-                                                               maximum = 30000),
-                                  variable_costs=10)},
+        label='battery',
+        inputs={b_el: solph.Flow()},
+        outputs={b_el: solph.Flow()},
         capacity_loss=0.001, 
-        nominal_capacity=50,
+        nominal_capacity=50,)
         inflow_conversion_factor=0.98, outflow_conversion_factor=0.8),
-        invest_relation_input_output = 1,
-        invest_relation_input_capacity = 1/6,
-        investment = solph.Investment(ep_costs=50) 
+        invest_relation_input_capacity = 1/6, invest_relation_output_capacity = 1/6
+        investment = solph.Investment(ep_costs=400) 
 
-The example presents a storage that has the input flow coupled to the capacity as well as the input flow to the output flow.
 
 .. note:: See the :py:class:`~oemof.solph.components.GenericStorage` class for all parameters and the mathematical background.
 

--- a/doc/oemof_solph.rst
+++ b/doc/oemof_solph.rst
@@ -434,10 +434,50 @@ Furthermore, an efficiency for loading, unloading and a capacity loss per time i
 
 .. note:: See the :py:class:`~oemof.solph.components.GenericStorage` class for all parameters and the mathematical background.
 
+Using the investment object with the GenericStorage component:
+
+The `GenericInvestmentStorageBlock` enables the investment mode for storages to optimise dispatch and investment. It is 
+based on the `GenericStorage` component and there are two main investment possibilities.
+
+    *	Invest into the flow parameters enables to invest into the power side e.g. a turbine or a pump
+    *	Invest into capacity of the storage enables to invest into the amount of storage capacity e.g. a basin 
+    
+As an addition to other flow-investments, the storage class implements the possibility to couple or decouple the flows 
+with the capacity of the storage. 
+Three parameters are responsible for connecting the flows and the capacity of the storage:
+
+    *	`invest_relation_input_capacity’ fixes the inflow to the capacity. A ratio of ‘1’ means that the storage can be emptied
+     within one time-period. 
+    *	`invest_relation_output_capacity’ fixes the outflow to the capacity. A ratio of ‘1’ means that the storage can be
+     emptied within one period.
+    *	`invest_relation_input_output` fixes the input flow to the output flow. For values <1, the input will be smaller
+     and for values >1 the input flow will be larger. 
+    
+Not all 3 parameters can be set at the same time. 
+The optimization problem will then determine the optimal capacity as well as the optimal flows.
+
+.. code-block:: python
+
+    solph.GenericStorage(
+        label='storage',
+        inputs={b_el: solph.Flow(investment= solph.Investment(ep_costs=100, existing = 20000, maximum = 30000))},
+        outputs={b_el: solph.Flow(investment= solph.Investment(ep_costs=100, existing = 20000, maximum = 30000), 
+                variable_costs=10)},
+        capacity_loss=0.001, 
+        nominal_capacity=50,
+        inflow_conversion_factor=0.98, outflow_conversion_factor=0.8),
+        invest_relation_input_output = 1, invest_relation_input_capacity = 1/6,
+        investment = solph.Investment(ep_costs=50) 
+
+
+
+
+.. note:: See the :py:class:`~oemof.solph.components.GenericStorageInvestment` class for all parameters and the mathematical background.
+
+
 
 .. _oemof_solph_custom_electrical_line_label:
 
-GenericStorageInvestmentBlock Test test test
 
 ElectricalLine (custom)
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/oemof_solph.rst
+++ b/doc/oemof_solph.rst
@@ -466,9 +466,9 @@ This following example-storage is not usable. The input flow has to be 1/6 of th
         invest_relation_input_capacity = 1, invest_relation_output_capacity = 1/6,
         investment = solph.Investment(ep_costs=50) 
 
-.. code-block:: python
-
 Instead you should use the storage as follows (one example).
+
+.. code-block:: python
 
     solph.GenericStorage(
         label='storage',
@@ -486,10 +486,7 @@ Instead you should use the storage as follows (one example).
 
 The example presents a storage that has the input flow coupled to the capacity as well as the input flow to the output flow.
 
-
 .. note:: See the :py:class:`~oemof.solph.components.GenericStorage` class for all parameters and the mathematical background.
-.. note:: See the :py:class:`~oemof.solph.components.GenericInvestmentStorageBlock` class for all parameters and the mathematical background.
-
 
 
 .. _oemof_solph_custom_electrical_line_label:

--- a/doc/oemof_solph.rst
+++ b/doc/oemof_solph.rst
@@ -445,12 +445,9 @@ As an addition to other flow-investments, the storage class implements the possi
 with the capacity of the storage. 
 Three parameters are responsible for connecting the flows and the capacity of the storage:
 
-    *	`invest_relation_input_capacity` fixes the inflow to the capacity. A ratio of ‘1’ means that the storage can be emptied
-     within one time-period. 
-    *	`invest_relation_output_capacity` fixes the outflow to the capacity. A ratio of ‘1’ means that the storage can be
-     emptied within one period.
-    *	`invest_relation_input_output` fixes the input flow to the output flow. For values <1, the input will be smaller
-     and for values >1 the input flow will be larger. 
+    *	`invest_relation_input_capacity` fixes the inflow to the capacity. A ratio of ‘1’ means that the storage can be emptied within one time-period. 
+    *	`invest_relation_output_capacity` fixes the outflow to the capacity. A ratio of ‘1’ means that the storage can be emptied within one period.
+    *	`invest_relation_input_output` fixes the input flow to the output flow. For values <1, the input will be smaller and for values >1 the input flow will be larger. 
     
 Not all 3 parameters can be set at the same time. 
 The optimization problem will then determine the optimal capacity as well as the optimal flows.
@@ -469,7 +466,7 @@ The optimization problem will then determine the optimal capacity as well as the
         invest_relation_input_output = 1, invest_relation_input_capacity = 1/6,
         investment = solph.Investment(ep_costs=50) 
 
-
+The example presents a storage that has the input flow coupled to the capacity as well as the input flow to the output flow.
 
 
 .. note:: See the :py:class:`~oemof.solph.components.GenericStorage` class for all parameters and the mathematical background.

--- a/doc/oemof_solph.rst
+++ b/doc/oemof_solph.rst
@@ -433,7 +433,8 @@ Furthermore, an efficiency for loading, unloading and a capacity loss per time i
         inflow_conversion_factor=0.98, outflow_conversion_factor=0.8)
 
 
-Using the investment object with the GenericStorage component:
+Using the investment object with the GenericStorage component
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 The `GenericInvestmentStorageBlock` enables the investment mode for storages to optimise dispatch and investment. It is 
 based on the `GenericStorage` component and there are two main investment possibilities.
@@ -457,13 +458,15 @@ The optimization problem will then determine the optimal capacity as well as the
     solph.GenericStorage(
         label='storage',
         inputs={b_el: solph.Flow(investment= solph.Investment(ep_costs=100, existing = 20000, 
-                                    maximum = 30000))},
+                                                              maximum = 30000))},
         outputs={b_el: solph.Flow(investment= solph.Investment(ep_costs=100, existing = 20000, 
-                                    maximum = 30000), variable_costs=10)},
+                                                               maximum = 30000),
+                                  variable_costs=10)},
         capacity_loss=0.001, 
         nominal_capacity=50,
         inflow_conversion_factor=0.98, outflow_conversion_factor=0.8),
-        invest_relation_input_output = 1, invest_relation_input_capacity = 1/6,
+        invest_relation_input_output = 1,
+        invest_relation_input_capacity = 1/6,
         investment = solph.Investment(ep_costs=50) 
 
 The example presents a storage that has the input flow coupled to the capacity as well as the input flow to the output flow.

--- a/doc/oemof_solph.rst
+++ b/doc/oemof_solph.rst
@@ -433,7 +433,7 @@ Furthermore, an efficiency for loading, unloading and a capacity loss per time i
         inflow_conversion_factor=0.98, outflow_conversion_factor=0.8)
 
 
-Using the investment object with the GenericStorage component
+Using an investment object with the GenericStorage component
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Based on the `GenericStorage` object the `GenericInvestmentStorageBlock` adds two main investment possibilities.

--- a/doc/oemof_solph.rst
+++ b/doc/oemof_solph.rst
@@ -437,6 +437,8 @@ Furthermore, an efficiency for loading, unloading and a capacity loss per time i
 
 .. _oemof_solph_custom_electrical_line_label:
 
+GenericStorageInvestmentBlock Test test test
+
 ElectricalLine (custom)
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/oemof_solph.rst
+++ b/doc/oemof_solph.rst
@@ -447,13 +447,13 @@ As an addition to other flow-investments, the storage class implements the possi
 with the capacity of the storage. 
 Three parameters are responsible for connecting the flows and the capacity of the storage:
 
-    *	' `invest_relation_input_capacity` ' fixes the input flow investment to the capacity investment. A ratio of ‘1’ means that the storage can be emptied within one time-period. 
+    *	' `invest_relation_input_capacity` ' fixes the input flow investment to the capacity investment. A ratio of ‘1’ means that the storage can be filled within one time-period.
     *	' `invest_relation_output_capacity` ' fixes the output flow investment to the capacity investment. A ratio of ‘1’ means that the storage can be emptied within one period.
     *	' `invest_relation_input_output` ' fixes the input flow investment to the output flow investment. For values <1, the input will be smaller and for values >1 the input flow will be larger. 
     
-You should not set all 3 parameters at the same time, since it will lead to overditermination.
+You should not set all 3 parameters at the same time, since it will lead to overdetermination.
 
-The following example pictures a PHES. Both flows and the storage itself (representing: pump, turbine, basin) are free in their investment. You can set the parameters to `None` or delete them as `None` is the default value.   
+The following example pictures a Pumped Hydroelectric Energy Storage (PHES). Both flows and the storage itself (representing: pump, turbine, basin) are free in their investment. You can set the parameters to `None` or delete them as `None` is the default value.
 
 .. code-block:: python
 
@@ -463,7 +463,7 @@ The following example pictures a PHES. Both flows and the storage itself (repres
         outputs={b_el: solph.Flow(investment= solph.Investment(ep_costs=500)},
         capacity_loss=0.001, 
         inflow_conversion_factor=0.98, outflow_conversion_factor=0.8),
-        investment = solph.Investment(ep_costs=40) 
+        investment = solph.Investment(ep_costs=40))
 
 The following example describes a battery with flows coupled to the capacity of the storage.
 
@@ -474,10 +474,12 @@ The following example describes a battery with flows coupled to the capacity of 
         inputs={b_el: solph.Flow()},
         outputs={b_el: solph.Flow()},
         capacity_loss=0.001, 
-        nominal_capacity=50,)
-        inflow_conversion_factor=0.98, outflow_conversion_factor=0.8),
-        invest_relation_input_capacity = 1/6, invest_relation_output_capacity = 1/6
-        investment = solph.Investment(ep_costs=400) 
+        nominal_capacity=50,
+        inflow_conversion_factor=0.98,
+         outflow_conversion_factor=0.8,
+        invest_relation_input_capacity = 1/6,
+        invest_relation_output_capacity = 1/6,
+        investment = solph.Investment(ep_costs=400))
 
 
 .. note:: See the :py:class:`~oemof.solph.components.GenericStorage` class for all parameters and the mathematical background.

--- a/doc/oemof_solph.rst
+++ b/doc/oemof_solph.rst
@@ -432,23 +432,22 @@ Furthermore, an efficiency for loading, unloading and a capacity loss per time i
         capacity_loss=0.001, nominal_capacity=50,
         inflow_conversion_factor=0.98, outflow_conversion_factor=0.8)
 
-.. note:: See the :py:class:`~oemof.solph.components.GenericStorage` class for all parameters and the mathematical background.
 
 Using the investment object with the GenericStorage component:
 
 The `GenericInvestmentStorageBlock` enables the investment mode for storages to optimise dispatch and investment. It is 
 based on the `GenericStorage` component and there are two main investment possibilities.
 
-    *	Invest into the flow parameters enables to invest into the power side e.g. a turbine or a pump
-    *	Invest into capacity of the storage enables to invest into the amount of storage capacity e.g. a basin 
+    *	Invest into the flow parameters e.g. a turbine or a pump
+    *	Invest into capacity of the storage  e.g. a basin or a battery cell
     
 As an addition to other flow-investments, the storage class implements the possibility to couple or decouple the flows 
 with the capacity of the storage. 
 Three parameters are responsible for connecting the flows and the capacity of the storage:
 
-    *	`invest_relation_input_capacity’ fixes the inflow to the capacity. A ratio of ‘1’ means that the storage can be emptied
+    *	`invest_relation_input_capacity` fixes the inflow to the capacity. A ratio of ‘1’ means that the storage can be emptied
      within one time-period. 
-    *	`invest_relation_output_capacity’ fixes the outflow to the capacity. A ratio of ‘1’ means that the storage can be
+    *	`invest_relation_output_capacity` fixes the outflow to the capacity. A ratio of ‘1’ means that the storage can be
      emptied within one period.
     *	`invest_relation_input_output` fixes the input flow to the output flow. For values <1, the input will be smaller
      and for values >1 the input flow will be larger. 
@@ -460,9 +459,10 @@ The optimization problem will then determine the optimal capacity as well as the
 
     solph.GenericStorage(
         label='storage',
-        inputs={b_el: solph.Flow(investment= solph.Investment(ep_costs=100, existing = 20000, maximum = 30000))},
-        outputs={b_el: solph.Flow(investment= solph.Investment(ep_costs=100, existing = 20000, maximum = 30000), 
-                variable_costs=10)},
+        inputs={b_el: solph.Flow(investment= solph.Investment(ep_costs=100, existing = 20000, 
+                                    maximum = 30000))},
+        outputs={b_el: solph.Flow(investment= solph.Investment(ep_costs=100, existing = 20000, 
+                                    maximum = 30000), variable_costs=10)},
         capacity_loss=0.001, 
         nominal_capacity=50,
         inflow_conversion_factor=0.98, outflow_conversion_factor=0.8),
@@ -472,7 +472,7 @@ The optimization problem will then determine the optimal capacity as well as the
 
 
 
-.. note:: See the :py:class:`~oemof.solph.components.GenericStorageInvestment` class for all parameters and the mathematical background.
+.. note:: See the :py:class:`~oemof.solph.components.GenericStorage` class for all parameters and the mathematical background.
 
 
 

--- a/doc/oemof_solph.rst
+++ b/doc/oemof_solph.rst
@@ -453,7 +453,7 @@ Three parameters are responsible for connecting the flows and the capacity of th
     
 You should not set all 3 parameters at the same time, since it will lead to overditermination.
 
-This following example-storage pictures a PHES. Both flows and the storage itself (representing: pump, turbine, basin) are free in their investment. You can set the parameters to `None` or delete them as `None` is the default value.   
+The following example pictures a PHES. Both flows and the storage itself (representing: pump, turbine, basin) are free in their investment. You can set the parameters to `None` or delete them as `None` is the default value.   
 
 .. code-block:: python
 
@@ -465,7 +465,7 @@ This following example-storage pictures a PHES. Both flows and the storage itsel
         inflow_conversion_factor=0.98, outflow_conversion_factor=0.8),
         investment = solph.Investment(ep_costs=40) 
 
-The following example describes a battery where we have coupled the flows (representing power) to the capacity of the storage.
+The following example describes a battery with flows coupled to the capacity of the storage.
 
 .. code-block:: python
 

--- a/doc/oemof_solph.rst
+++ b/doc/oemof_solph.rst
@@ -441,6 +441,8 @@ Based on the `GenericStorage` object the `GenericInvestmentStorageBlock` adds tw
     *	Invest into the flow parameters e.g. a turbine or a pump
     *	Invest into capacity of the storage  e.g. a basin or a battery cell
     
+Investment in this context refers to the value of the variable for the 'nominal_value' (installed capacity) in the investment mode. 
+    
 As an addition to other flow-investments, the storage class implements the possibility to couple or decouple the flows 
 with the capacity of the storage. 
 Three parameters are responsible for connecting the flows and the capacity of the storage:
@@ -461,7 +463,7 @@ This following example-storage is not usable. The input flow has to be 1/6 of th
         capacity_loss=0.001, 
         inflow_conversion_factor=0.98, outflow_conversion_factor=0.8),
         invest_relation_input_output = 1
-        invest_relation_input_output = 1, invest_relation_input_capacity = 1/6,
+        invest_relation_input_capacity = 1, invest_relation_output_capacity = 1/6,
         investment = solph.Investment(ep_costs=50) 
 
 .. code-block:: python

--- a/doc/oemof_solph.rst
+++ b/doc/oemof_solph.rst
@@ -436,8 +436,7 @@ Furthermore, an efficiency for loading, unloading and a capacity loss per time i
 Using the investment object with the GenericStorage component
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-The `GenericInvestmentStorageBlock` enables the investment mode for storages to optimise dispatch and investment. It is 
-based on the `GenericStorage` component and there are two main investment possibilities.
+Based on the `GenericStorage` object the `GenericInvestmentStorageBlock` adds two main investment possibilities.
 
     *	Invest into the flow parameters e.g. a turbine or a pump
     *	Invest into capacity of the storage  e.g. a basin or a battery cell
@@ -446,14 +445,28 @@ As an addition to other flow-investments, the storage class implements the possi
 with the capacity of the storage. 
 Three parameters are responsible for connecting the flows and the capacity of the storage:
 
-    *	' `invest_relation_input_capacity` ' fixes the inflow to the capacity. A ratio of ‘1’ means that the storage can be emptied within one time-period. 
-    *	' `invest_relation_output_capacity` ' fixes the outflow to the capacity. A ratio of ‘1’ means that the storage can be emptied within one period.
-    *	' `invest_relation_input_output` ' fixes the input flow to the output flow. For values <1, the input will be smaller and for values >1 the input flow will be larger. 
+    *	' `invest_relation_input_capacity` ' fixes the input flow investment to the capacity investment. A ratio of ‘1’ means that the storage can be emptied within one time-period. 
+    *	' `invest_relation_output_capacity` ' fixes the output flow investment to the capacity investment. A ratio of ‘1’ means that the storage can be emptied within one period.
+    *	' `invest_relation_input_output` ' fixes the input flow investment to the output flow investment. For values <1, the input will be smaller and for values >1 the input flow will be larger. 
     
-Not all 3 parameters can be set at the same time. 
-The optimization problem will then determine the optimal capacity as well as the optimal flows.
+You should not set all 3 parameters at the same time, since it will lead to overditermination
+This following example-storage is not usable. The input flow has to be 1/6 of the capacity whereas the output has to be equal to the capacity and additionally both flows shall be equal.
 
 .. code-block:: python
+
+    solph.GenericStorage(
+        label='storage',
+        inputs={b_el: solph.Flow(investment= solph.Investment(ep_costs=100))},
+        outputs={b_el: solph.Flow(investment= solph.Investment(ep_costs=100)},
+        capacity_loss=0.001, 
+        inflow_conversion_factor=0.98, outflow_conversion_factor=0.8),
+        invest_relation_input_output = 1
+        invest_relation_input_output = 1, invest_relation_input_capacity = 1/6,
+        investment = solph.Investment(ep_costs=50) 
+
+.. code-block:: python
+
+Instead you should use the storage as follows (one example).
 
     solph.GenericStorage(
         label='storage',
@@ -473,6 +486,7 @@ The example presents a storage that has the input flow coupled to the capacity a
 
 
 .. note:: See the :py:class:`~oemof.solph.components.GenericStorage` class for all parameters and the mathematical background.
+.. note:: See the :py:class:`~oemof.solph.components.GenericInvestmentStorageBlock` class for all parameters and the mathematical background.
 
 
 

--- a/oemof/outputlib/processing.py
+++ b/oemof/outputlib/processing.py
@@ -323,7 +323,8 @@ def param_results(system, exclude_none=True, keys_as_str=False):
 
     Parameters
     ----------
-    system: Model or EnergySystem
+    system: energy_system.EnergySystem
+        A populated energy system.
     exclude_none: bool
         If True, all scalars and sequences containing None values are excluded
     keys_as_str: bool

--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -58,8 +58,8 @@ class GenericStorage(network.Transformer):
         Ratio between the investment variable of the output Flow and the
         investment variable of the storage.
 
-        .. math:: input\_invest =
-                  capacity\_invest \cdot invest\_relation\_input\_capacity
+        .. math:: output\_invest =
+                  capacity\_invest \cdot invest\_relation\_output\_capacity
 
     invest_relation_input_output : numeric or None
         Ratio between the investment variable of the output Flow and the

--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -96,8 +96,8 @@ class GenericStorage(network.Transformer):
         nominal_capacity should not be set (or set to None) if an investment
         object is used.
 
-    Notes
-    -----
+    Note
+    ----
     The following sets, variables, constraints and objective parts are created
      * :py:class:`~oemof.solph.components.GenericStorageBlock` (if no
        Investment object present)
@@ -597,7 +597,8 @@ class GenericCHP(network.Transformer):
     Volume 78, Issue 5, May 2008, Pages 835-848
     https://doi.org/10.1016/j.epsr.2007.06.001
 
-    Notes:
+    Note
+    ----
     An adaption for the flow parameter `H_L_FG_share_max` has been made to
     set the flue gas losses at maximum fuel flow `H_L_FG_max` as share of
     the fuel flow `H_F` e.g. for combined cycle extraction turbines.
@@ -629,8 +630,8 @@ class GenericCHP(network.Transformer):
         Flag to use back-pressure characteristics. Works of set to `True` and
         `Q_CW_min` set to zero. See paper above for more information.
 
-    Notes
-    -----
+    Note
+    ----
     The following sets, variables, constraints and objective parts are created
      * :py:class:`~oemof.solph.components.GenericCHPBlock`
 
@@ -929,8 +930,8 @@ class ExtractionTurbineCHP(solph_Transformer):
         key is allowed. Use one of the keys of the conversion factors. The key
         indicates the main flow. The other output flow is the tapped flow.
 
-    Notes
-    -----
+    Note
+    ----
     The following sets, variables, constraints and objective parts are created
      * :py:class:`~oemof.solph.components.ExtractionTurbineCHPBlock`
 


### PR DESCRIPTION
Added some explanations about the speciality of storage Investments as well as an example.

Main difference seems to be the possibility of coupling and decoupling

The interpreted changes can be found here:

https://oemof.readthedocs.io/en/documentation-improve_storage_docs/oemof_solph.html#genericstorage-component
 