### PR TITLE
Fix/tuple as label causes problems

### DIFF
--- a/doc/whatsnew/v0-2-3.rst
+++ b/doc/whatsnew/v0-2-3.rst
@@ -26,6 +26,7 @@ Known issues
 
 Bug fixes
 #########
+* Some functions did not work with tuples as labels. It has been fixed for the ExtractionTurbineCHP, the graph module and the parameter_as_dict function. (`Issue #507 <https://github.com/oemof/oemof/issues/507>`_)
 
 
 Testing

--- a/oemof/graph.py
+++ b/oemof/graph.py
@@ -52,7 +52,7 @@ def create_nx_graph(energy_system=None, optimization_model=None,
     ...                  inputs = {bel1: Flow(nominal_value=85,
     ...                            actual_value=[0.5, 0.25, 0.75],
     ...                            fixed=True)})
-    >>> pp_gas = Transformer(label='pp_gas',
+    >>> pp_gas = Transformer(label=('pp', 'gas'),
     ...                            inputs={b_gas: Flow()},
     ...                            outputs={bel1: Flow(nominal_value=41,
     ...                                                variable_costs=40)},
@@ -67,7 +67,7 @@ def create_nx_graph(energy_system=None, optimization_model=None,
     >>> # sorted and customized. this is especially helpful for large graphs
     >>> # grph.create_nx_graph(es, filename="my_graph.graphml")
     >>> [my_graph.has_node(n)
-    ...  for n in ['b_gas', 'bel1', 'pp_gas', 'demand_el', 'tester']]
+    ...  for n in ['b_gas', 'bel1', "('pp', 'gas')", 'demand_el', 'tester']]
     [True, True, True, True, False]
     >>> list(nx.attracting_components(my_graph))
     [{'demand_el'}]
@@ -79,9 +79,9 @@ def create_nx_graph(energy_system=None, optimization_model=None,
     ...                                  remove_edges=[('bel2', 'line_from2')],
     ...                                  filename='test_graph')
     >>> [new_graph.has_node(n)
-    ...  for n in ['b_gas', 'bel1', 'pp_gas', 'demand_el', 'tester']]
+    ...  for n in ['b_gas', 'bel1', '(pp, gas)', 'demand_el', 'tester']]
     [False, True, False, True, False]
-    >>> my_graph.has_edge('pp_gas', 'bel1')
+    >>> my_graph.has_edge("('pp', 'gas')", 'bel1')
     True
     >>> new_graph.has_edge('bel2', 'line_from2')
     False

--- a/oemof/graph.py
+++ b/oemof/graph.py
@@ -75,11 +75,11 @@ def create_nx_graph(energy_system=None, optimization_model=None,
     ['bel1', 'bel2', 'line_from2', 'line_to2']
     >>> new_graph = grph.create_nx_graph(energy_system=es,
     ...                                  remove_nodes_with_substrings=['b_'],
-    ...                                  remove_nodes=['pp_gas'],
+    ...                                  remove_nodes=["('pp', 'gas')"],
     ...                                  remove_edges=[('bel2', 'line_from2')],
     ...                                  filename='test_graph')
     >>> [new_graph.has_node(n)
-    ...  for n in ['b_gas', 'bel1', '(pp, gas)', 'demand_el', 'tester']]
+    ...  for n in ['b_gas', 'bel1', "('pp', 'gas')", 'demand_el', 'tester']]
     [False, True, False, True, False]
     >>> my_graph.has_edge("('pp', 'gas')", 'bel1')
     True

--- a/oemof/graph.py
+++ b/oemof/graph.py
@@ -104,7 +104,7 @@ def create_nx_graph(energy_system=None, optimization_model=None,
 
     # add nodes
     for n in energy_system.nodes:
-        grph.add_node(n.label, label=n.label)
+        grph.add_node(str(n.label), label=str(n.label))
 
     # add labeled flows on directed edge if an optimization_model has been
     # passed or undirected edge otherwise
@@ -113,9 +113,10 @@ def create_nx_graph(energy_system=None, optimization_model=None,
             weight = getattr(energy_system.flows()[(i, n)],
                              'nominal_value', None)
             if weight is None:
-                grph.add_edge(i.label, n.label)
+                grph.add_edge(str(i.label), str(n.label))
             else:
-                grph.add_edge(i.label, n.label, weigth=format(weight, '.2f'))
+                grph.add_edge(str(i.label), str(n.label),
+                              weigth=format(weight, '.2f'))
 
     # remove nodes and edges based on precise labels
     if remove_nodes is not None:
@@ -126,8 +127,8 @@ def create_nx_graph(energy_system=None, optimization_model=None,
     # remove nodes based on substrings
     if remove_nodes_with_substrings is not None:
         for i in remove_nodes_with_substrings:
-            remove_nodes = [v.label for v in energy_system.nodes
-                            if i in v.label]
+            remove_nodes = [str(v.label) for v in energy_system.nodes
+                            if i in str(v.label)]
             grph.remove_nodes_from(remove_nodes)
 
     if filename is not None:

--- a/oemof/outputlib/processing.py
+++ b/oemof/outputlib/processing.py
@@ -256,6 +256,11 @@ def __separate_attrs(system, get_flows=False, exclude_none=True):
                 com_data['scalars'][a] = attr_value
                 continue
 
+            # If the label is a tuple it is iterable, therefore it should be
+            # converted to a string. Otherwise it will be a sequence.
+            if a == 'label':
+                attr_value = str(attr_value)
+
             # check if attribute is iterable
             # see: https://stackoverflow.com/questions/1952464/
             # in-python-how-do-i-determine-if-an-object-is-iterable

--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -1081,28 +1081,21 @@ class ExtractionTurbineCHPBlock(SimpleBlock):
 
         for n in group:
             n.inflow = list(n.inputs)[0]
-            n.label_main_flow = str(
+            n.main_flow = (
                 [k for k, v in n.conversion_factor_full_condensation.items()]
                 [0])
-            n.main_output = [o for o in n.outputs
-                             if n.label_main_flow == str(o.label)][0]
-            n.tapped_output = [o for o in n.outputs
-                               if n.label_main_flow != str(o.label)][0]
+            n.main_output = [o for o in n.outputs if n.main_flow == o][0]
+            n.tapped_output = [o for o in n.outputs if n.main_flow != o][0]
             n.conversion_factor_full_condensation_sq = (
-                n.conversion_factor_full_condensation[
-                    m.es.groups[str(n.main_output.label)]])
+                n.conversion_factor_full_condensation[n.main_output])
             n.flow_relation_index = [
-                n.conversion_factors[
-                    m.es.groups[str(n.main_output.label)]][t] /
-                n.conversion_factors[
-                    m.es.groups[str(n.tapped_output.label)]][t]
+                n.conversion_factors[n.main_output][t] /
+                n.conversion_factors[n.tapped_output][t]
                 for t in m.TIMESTEPS]
             n.main_flow_loss_index = [
                 (n.conversion_factor_full_condensation_sq[t] -
-                 n.conversion_factors[m.es.groups[
-                     str(n.main_output.label)]][t]) /
-                n.conversion_factors[m.es.groups[
-                    str(n.tapped_output.label)]][t]
+                 n.conversion_factors[n.main_output][t]) /
+                n.conversion_factors[n.tapped_output][t]
                 for t in m.TIMESTEPS]
 
         def _input_output_relation_rule(block):

--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -1085,20 +1085,24 @@ class ExtractionTurbineCHPBlock(SimpleBlock):
                 [k for k, v in n.conversion_factor_full_condensation.items()]
                 [0])
             n.main_output = [o for o in n.outputs
-                             if n.label_main_flow == o.label][0]
+                             if n.label_main_flow == str(o.label)][0]
             n.tapped_output = [o for o in n.outputs
-                               if n.label_main_flow != o.label][0]
+                               if n.label_main_flow != str(o.label)][0]
             n.conversion_factor_full_condensation_sq = (
                 n.conversion_factor_full_condensation[
-                    m.es.groups[n.main_output.label]])
+                    m.es.groups[str(n.main_output.label)]])
             n.flow_relation_index = [
-                n.conversion_factors[m.es.groups[n.main_output.label]][t] /
-                n.conversion_factors[m.es.groups[n.tapped_output.label]][t]
+                n.conversion_factors[
+                    m.es.groups[str(n.main_output.label)]][t] /
+                n.conversion_factors[
+                    m.es.groups[str(n.tapped_output.label)]][t]
                 for t in m.TIMESTEPS]
             n.main_flow_loss_index = [
                 (n.conversion_factor_full_condensation_sq[t] -
-                 n.conversion_factors[m.es.groups[n.main_output.label]][t]) /
-                n.conversion_factors[m.es.groups[n.tapped_output.label]][t]
+                 n.conversion_factors[m.es.groups[
+                     str(n.main_output.label)]][t]) /
+                n.conversion_factors[m.es.groups[
+                    str(n.tapped_output.label)]][t]
                 for t in m.TIMESTEPS]
 
         def _input_output_relation_rule(block):

--- a/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
+++ b/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
@@ -100,8 +100,10 @@ def test_variable_chp(filename="variable_chp.csv", solver='cbc'):
     om.solve(solver=solver)
 
     optimisation_results = outputlib.processing.results(om)
+    parameter = outputlib.processing.parameter_as_dict(energysystem)
 
-    myresults = outputlib.views.node(optimisation_results, "('natural', 'gas')")
+    myresults = outputlib.views.node(optimisation_results,
+                                     "('natural', 'gas')")
     sumresults = myresults['sequences'].sum(axis=0)
     maxresults = myresults['sequences'].max(axis=0)
 
@@ -124,6 +126,11 @@ def test_variable_chp(filename="variable_chp.csv", solver='cbc'):
         logging.debug("Test the summed up value of {0}".format(key))
         eq_(int(round(sumresults[key])),
             int(round(variable_chp_dict_sum[key])))
+
+    eq_(parameter[(energysystem.groups["('fixed_chp', 'gas')"], None)]
+        ['scalars']['label'], "('fixed_chp', 'gas')")
+    eq_(parameter[(energysystem.groups["('fixed_chp', 'gas')"], None)]
+          ['scalars']["conversion_factors_('electricity', 2)"], 0.3)
 
     # objective function
     eq_(round(outputlib.processing.meta_results(om)['objective']), 326661590)

--- a/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
+++ b/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
@@ -42,45 +42,46 @@ def test_variable_chp(filename="variable_chp.csv", solver='cbc'):
     logging.info('Create oemof.solph objects')
 
     # create natural gas bus
-    bgas = solph.Bus(label="natural_gas")
+    bgas = solph.Bus(label=('natural', 'gas'))
 
     # create commodity object for gas resource
-    solph.Source(label='rgas', outputs={bgas: solph.Flow(variable_costs=50)})
+    solph.Source(label=('commodity', 'gas'),
+                 outputs={bgas: solph.Flow(variable_costs=50)})
 
     # create two electricity buses and two heat buses
-    bel = solph.Bus(label="electricity")
-    bel2 = solph.Bus(label="electricity_2")
-    bth = solph.Bus(label="heat")
-    bth2 = solph.Bus(label="heat_2")
+    bel = solph.Bus(label=('electricity', 1))
+    bel2 = solph.Bus(label=('electricity', 2))
+    bth = solph.Bus(label=('heat', 1))
+    bth2 = solph.Bus(label=('heat', 2))
 
     # create excess components for the elec/heat bus to allow overproduction
-    solph.Sink(label='excess_bth_2', inputs={bth2: solph.Flow()})
-    solph.Sink(label='excess_therm', inputs={bth: solph.Flow()})
-    solph.Sink(label='excess_bel_2', inputs={bel2: solph.Flow()})
-    solph.Sink(label='excess_elec', inputs={bel: solph.Flow()})
+    solph.Sink(label=('excess', 'bth_2'), inputs={bth2: solph.Flow()})
+    solph.Sink(label=('excess', 'bth_1'), inputs={bth: solph.Flow()})
+    solph.Sink(label=('excess', 'bel_2'), inputs={bel2: solph.Flow()})
+    solph.Sink(label=('excess', 'bel_1'), inputs={bel: solph.Flow()})
 
     # create simple sink object for electrical demand for each electrical bus
-    solph.Sink(label='demand_elec', inputs={bel: solph.Flow(
+    solph.Sink(label=('demand', 'elec1'), inputs={bel: solph.Flow(
         actual_value=data['demand_el'], fixed=True, nominal_value=1)})
-    solph.Sink(label='demand_el_2', inputs={bel2: solph.Flow(
+    solph.Sink(label=('demand', 'elec2'), inputs={bel2: solph.Flow(
         actual_value=data['demand_el'], fixed=True, nominal_value=1)})
 
     # create simple sink object for heat demand for each thermal bus
-    solph.Sink(label='demand_therm', inputs={bth: solph.Flow(
+    solph.Sink(label=('demand', 'therm1'), inputs={bth: solph.Flow(
         actual_value=data['demand_th'], fixed=True, nominal_value=741000)})
-    solph.Sink(label='demand_th_2', inputs={bth2: solph.Flow(
+    solph.Sink(label=('demand', 'therm2'), inputs={bth2: solph.Flow(
         actual_value=data['demand_th'], fixed=True, nominal_value=741000)})
 
     # create a fixed transformer to distribute to the heat_2 and elec_2 buses
     solph.Transformer(
-        label='fixed_chp_gas',
+        label=('fixed_chp', 'gas'),
         inputs={bgas: solph.Flow(nominal_value=10e10)},
         outputs={bel2: solph.Flow(), bth2: solph.Flow()},
         conversion_factors={bel2: 0.3, bth2: 0.5})
 
     # create a fixed transformer to distribute to the heat and elec buses
     solph.components.ExtractionTurbineCHP(
-        label='variable_chp_gas',
+        label=('variable_chp', 'gas'),
         inputs={bgas: solph.Flow(nominal_value=10e10)},
         outputs={bel: solph.Flow(), bth: solph.Flow()},
         conversion_factors={bel: 0.3, bth: 0.5},
@@ -100,27 +101,29 @@ def test_variable_chp(filename="variable_chp.csv", solver='cbc'):
 
     optimisation_results = outputlib.processing.results(om)
 
-    myresults = outputlib.views.node(optimisation_results, 'natural_gas')
+    myresults = outputlib.views.node(optimisation_results, "('natural', 'gas')")
     sumresults = myresults['sequences'].sum(axis=0)
     maxresults = myresults['sequences'].max(axis=0)
 
     variable_chp_dict_sum = {
-        (('natural_gas', 'fixed_chp_gas'), 'flow'): 3710208,
-        (('natural_gas', 'variable_chp_gas'), 'flow'): 2823024,
-        (('rgas', 'natural_gas'), 'flow'): 6533232}
+        (("('natural', 'gas')", "('variable_chp', 'gas')"), 'flow'): 2823024,
+        (("('natural', 'gas')", "('fixed_chp', 'gas')"), 'flow'): 3710208,
+        (("('commodity', 'gas')", "('natural', 'gas')"), 'flow'): 6533232}
 
     variable_chp_dict_max = {
-        (('natural_gas', 'fixed_chp_gas'), 'flow'): 785934,
-        (('natural_gas', 'variable_chp_gas'), 'flow'): 630332,
-        (('rgas', 'natural_gas'), 'flow'): 1416266}
+        (("('natural', 'gas')", "('variable_chp', 'gas')"), 'flow'): 630332,
+        (("('natural', 'gas')", "('fixed_chp', 'gas')"), 'flow'): 785934,
+        (("('commodity', 'gas')", "('natural', 'gas')"), 'flow'): 1416266}
 
     for key in variable_chp_dict_max.keys():
         logging.debug("Test the maximum value of {0}".format(key))
-        eq_(int(round(maxresults[key])), int(round(variable_chp_dict_max[key])))
+        eq_(int(round(maxresults[key])),
+            int(round(variable_chp_dict_max[key])))
 
     for key in variable_chp_dict_sum.keys():
         logging.debug("Test the summed up value of {0}".format(key))
-        eq_(int(round(sumresults[key])), int(round(variable_chp_dict_sum[key])))
+        eq_(int(round(sumresults[key])),
+            int(round(variable_chp_dict_sum[key])))
 
     # objective function
     eq_(round(outputlib.processing.meta_results(om)['objective']), 326661590)


### PR DESCRIPTION
If we use tuples as labels as it was originally intended but never used some errors occur.

I fixed some of these bugs and adapted some tests. 

- ExtractionTurbineCHP now uses objects instead of labels
- The graph module uses the string of the label instead of the label (`str(n.label)` instead of `n.label`)
- in the `detect_scalars_and_sequences` function the label is filtered to be not detected as sequence if the label is a tuple.

I want to merge them soon.