### PR TITLE
Change existing test to make it fail

### DIFF
--- a/oemof/network.py
+++ b/oemof/network.py
@@ -225,7 +225,7 @@ class Node:
     def __lt__(self, other):
         if other is None:
             return False
-        return self.label < other.label
+        return str(self.label) < str(other.label)
 
     def __hash__(self):
         return hash(self.label)

--- a/oemof/network.py
+++ b/oemof/network.py
@@ -223,10 +223,7 @@ class Node:
         return id(self) == id(other)
 
     def __lt__(self, other):
-        try:
-            return str(self.label) < str(other.label)
-        except AttributeError:
-            return False
+        return str(self) < str(other)
 
     def __hash__(self):
         return hash(self.label)

--- a/oemof/network.py
+++ b/oemof/network.py
@@ -223,9 +223,10 @@ class Node:
         return id(self) == id(other)
 
     def __lt__(self, other):
-        if other is None:
+        try:
+            return str(self.label) < str(other.label)
+        except AttributeError:
             return False
-        return str(self.label) < str(other.label)
 
     def __hash__(self):
         return hash(self.label)

--- a/tests/test_scripts/test_solph/test_storage_investment/test_invest_storage_regression.py
+++ b/tests/test_scripts/test_solph/test_storage_investment/test_invest_storage_regression.py
@@ -29,8 +29,8 @@ def test_regression_investment_storage(solver='cbc'):
     Node.registry = energysystem
 
     # Buses
-    bgas = solph.Bus(label="natural_gas")
-    bel = solph.Bus(label="electricity")
+    bgas = solph.Bus(label=('natural', 'gas'))
+    bel = solph.Bus(label='electricity')
 
     solph.Sink(label='demand', inputs={bel: solph.Flow(
         actual_value=[209643, 207497, 200108, 191892], fixed=True,
@@ -41,7 +41,7 @@ def test_regression_investment_storage(solver='cbc'):
 
     # Transformer
     solph.Transformer(
-        label="pp_gas",
+        label='pp_gas',
         inputs={bgas: solph.Flow()},
         outputs={bel: solph.Flow(nominal_value=300000)},
         conversion_factors={bel: 0.58})


### PR DESCRIPTION
It should be possible to use tuple and(!) string labels in one EnergySystem. At the moment it is only possible to use either string or tuple labels.

If you mix them you get the following error:
```python
  File ".virtualenv/oemof_cosmos/lib/python3.5/site-packages/pyomo/core/base/block.py", line 1314, in component_data_objects sort=sort):
  File ".virtualenv/oemof_cosmos/lib/python3.5/site-packages/pyomo/core/base/block.py", line 1244, in _component_data_iter _items = sorted(_items, key=itemgetter(0))
  File "oemof/oemof/network.py", line 228, in __lt__
    return self.label < other.label
```