### PR TITLE
Add operation cost independent from output to NONCONVEX_FLOW

### DIFF
--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -863,6 +863,6 @@ class NonConvexFlow(SimpleBlock):
                         m.flows[i, o].nonconvex.activity_costs[t]
                         for t in m.TIMESTEPS)
 
-            self.operationcosts = Expression(expr=activitycosts)
+            self.activitycosts = Expression(expr=activitycosts)
 
         return startcosts + shutdowncosts + activitycosts

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -582,6 +582,9 @@ class NonConvexFlow(SimpleBlock):
     SHUTDOWN_FLOWS
         A subset of set NONCONVEX_FLOWS with the attribute
         :attr:`shutdown_costs` being not None.
+    OPR_FLOWS
+        A subset of set NONCONVEX_FLOWS with the attribute
+        :attr:`opr_costs` being not None.
 
     MINUPTIMEFLOWS
         A subset of set NONCONVEX_FLOWS with the attribute
@@ -678,6 +681,11 @@ class NonConvexFlow(SimpleBlock):
             \sum_{i, o \in SHUTDOWN\_FLOWS} \sum_t shutdown(i, o, t) \
                 \cdot shutdown\_costs(i, o)
 
+    If :attr:`nonconvex.opr_costs` is set by the user:
+        .. math::
+            \sum_{i, o \in OPR\_FLOWS} \sum_t status(i, o, t) \
+                \cdot opr\_costs(i, o)
+
     """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -717,6 +725,10 @@ class NonConvexFlow(SimpleBlock):
         self.MINDOWNTIMEFLOWS = Set(initialize=[(g[0], g[1]) for g in group
                                     if g[2].nonconvex.minimum_downtime
                                     is not None])
+
+        self.OPR_FLOWS = Set(initialize=[(g[0], g[1]) for g in group
+                                 if g[2].nonconvex.opr_costs[0]
+                                 is not None])
 
         # ################### VARIABLES AND CONSTRAINTS #######################
         self.status = Var(self.NONCONVEX_FLOWS, m.TIMESTEPS, within=Binary)
@@ -824,6 +836,7 @@ class NonConvexFlow(SimpleBlock):
 
         startcosts = 0
         shutdowncosts = 0
+        operationcosts = 0
 
         if self.STARTUPFLOWS:
             for i, o in self.STARTUPFLOWS:
@@ -842,4 +855,14 @@ class NonConvexFlow(SimpleBlock):
                         for t in m.TIMESTEPS)
             self.shutdowncosts = Expression(expr=shutdowncosts)
 
-        return startcosts + shutdowncosts
+        if self.OPR_FLOWS:
+            for i,o in self.OPR_FLOWS:
+                if m.flows[i, o].nonconvex.opr_costs[0] is not None :
+                    operationcosts += sum(
+                        self.status[i, o, t] *
+                        m.flows[i, o].nonconvex.opr_costs[t]
+                        for t in m.TIMESTEPS)
+
+            self.operationcosts = Expression(expr=operationcosts)
+
+        return startcosts + shutdowncosts + operationcosts

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -582,9 +582,9 @@ class NonConvexFlow(SimpleBlock):
     SHUTDOWN_FLOWS
         A subset of set NONCONVEX_FLOWS with the attribute
         :attr:`shutdown_costs` being not None.
-    OPR_FLOWS
+    ACTIVE_FLOWS
         A subset of set NONCONVEX_FLOWS with the attribute
-        :attr:`opr_costs` being not None.
+        :attr:`activity_costs` being not None.
 
     MINUPTIMEFLOWS
         A subset of set NONCONVEX_FLOWS with the attribute
@@ -681,10 +681,10 @@ class NonConvexFlow(SimpleBlock):
             \sum_{i, o \in SHUTDOWN\_FLOWS} \sum_t shutdown(i, o, t) \
                 \cdot shutdown\_costs(i, o)
 
-    If :attr:`nonconvex.opr_costs` is set by the user:
+    If :attr:`nonconvex.activity_costs` is set by the user:
         .. math::
-            \sum_{i, o \in OPR\_FLOWS} \sum_t status(i, o, t) \
-                \cdot opr\_costs(i, o)
+            \sum_{i, o \in ACTIVE\_FLOWS} \sum_t status(i, o, t) \
+                \cdot activity\_costs(i, o)
 
     """
     def __init__(self, *args, **kwargs):
@@ -726,8 +726,8 @@ class NonConvexFlow(SimpleBlock):
                                     if g[2].nonconvex.minimum_downtime
                                     is not None])
 
-        self.OPR_FLOWS = Set(initialize=[(g[0], g[1]) for g in group
-                                 if g[2].nonconvex.opr_costs[0]
+        self.ACTIVE_FLOWS = Set(initialize=[(g[0], g[1]) for g in group
+                                 if g[2].nonconvex.activity_costs[0]
                                  is not None])
 
         # ################### VARIABLES AND CONSTRAINTS #######################
@@ -836,7 +836,7 @@ class NonConvexFlow(SimpleBlock):
 
         startcosts = 0
         shutdowncosts = 0
-        operationcosts = 0
+        activitycosts = 0
 
         if self.STARTUPFLOWS:
             for i, o in self.STARTUPFLOWS:
@@ -855,14 +855,14 @@ class NonConvexFlow(SimpleBlock):
                         for t in m.TIMESTEPS)
             self.shutdowncosts = Expression(expr=shutdowncosts)
 
-        if self.OPR_FLOWS:
+        if self.ACTIVE_FLOWS:
             for i,o in self.OPR_FLOWS:
                 if m.flows[i, o].nonconvex.opr_costs[0] is not None :
-                    operationcosts += sum(
+                    activitycosts += sum(
                         self.status[i, o, t] *
-                        m.flows[i, o].nonconvex.opr_costs[t]
+                        m.flows[i, o].nonconvex.activity_costs[t]
                         for t in m.TIMESTEPS)
 
-            self.operationcosts = Expression(expr=operationcosts)
+            self.operationcosts = Expression(expr=activitycosts)
 
-        return startcosts + shutdowncosts + operationcosts
+        return startcosts + shutdowncosts + activitycosts

--- a/oemof/solph/options.py
+++ b/oemof/solph/options.py
@@ -43,6 +43,9 @@ class NonConvex:
         Costs associated with a start of the flow (representing a unit).
     shutdown_costs : numeric
         Costs associated with the shutdown of the flow (representing a unit).
+    opr_costs : numeric
+        Costs associated with the operation of the flow independently from the
+        actual output (representing a unit).
     minimum_uptime : numeric (1 or positive integer)
         Minimum time that a flow must be greater then its minimum flow after
         startup. Be aware that minimum up and downtimes can contradict each
@@ -63,7 +66,7 @@ class NonConvex:
     """
     def __init__(self, **kwargs):
         scalars = ['minimum_uptime', 'minimum_downtime', 'initial_status']
-        sequences = ['startup_costs', 'shutdown_costs']
+        sequences = ['startup_costs', 'shutdown_costs','opr_costs']
         defaults = {'initial_status': 0}
 
         for attribute in set(scalars + sequences + list(kwargs)):

--- a/oemof/solph/options.py
+++ b/oemof/solph/options.py
@@ -43,8 +43,8 @@ class NonConvex:
         Costs associated with a start of the flow (representing a unit).
     shutdown_costs : numeric
         Costs associated with the shutdown of the flow (representing a unit).
-    opr_costs : numeric
-        Costs associated with the operation of the flow independently from the
+    activity_costs : numeric
+        Costs associated with the active operation of the flow independently from the
         actual output (representing a unit).
     minimum_uptime : numeric (1 or positive integer)
         Minimum time that a flow must be greater then its minimum flow after
@@ -66,7 +66,7 @@ class NonConvex:
     """
     def __init__(self, **kwargs):
         scalars = ['minimum_uptime', 'minimum_downtime', 'initial_status']
-        sequences = ['startup_costs', 'shutdown_costs','opr_costs']
+        sequences = ['startup_costs', 'shutdown_costs','activity_costs']
         defaults = {'initial_status': 0}
 
         for attribute in set(scalars + sequences + list(kwargs)):


### PR DESCRIPTION
This PR implements the functionality of adding operation cost independently from the output at each time interval. As a result, opr_cost can be now attributed the NONCONVEX_FLOW objects which occur whenever the status of nonconvex flow is 1, otherwise they are 0. 

For me, this functionality was practically useful when modelling e.g. DieselGenerator (DG), as it allowed me to add fix operation cost in case the DG-component is running.

Changes are made to oemof/solph/blocks.py and oemof/sopf/options.py

What do you _think?