### PR TITLE
Squelch deprecation warning when testing processing

### DIFF
--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -116,9 +116,7 @@ class Parameter_Result_Tests:
         """
         b_el2 = self.es.groups['b_el2']
         demand = self.es.groups['demand_el']
-        param_results = processing.parameter_as_dict(
-                self.es,
-                exclude_none=False)
+        param_results = processing.param_results(self.es, exclude_none=False)
 
         scalar_attributes = {
             'fixed': True,

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -116,7 +116,9 @@ class Parameter_Result_Tests:
         """
         b_el2 = self.es.groups['b_el2']
         demand = self.es.groups['demand_el']
-        param_results = processing.param_results(self.es, exclude_none=False)
+        param_results = processing.parameter_as_dict(
+                self.es,
+                exclude_none=False)
 
         scalar_attributes = {
             'fixed': True,

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -10,6 +10,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 """
 
 from nose.tools import eq_, assert_raises
+from warnings import catch_warnings
 import pandas
 from pandas.util.testing import assert_series_equal, assert_frame_equal
 from oemof.solph import (
@@ -116,7 +117,18 @@ class Parameter_Result_Tests:
         """
         b_el2 = self.es.groups['b_el2']
         demand = self.es.groups['demand_el']
-        param_results = processing.param_results(self.es, exclude_none=False)
+        with catch_warnings(record=True) as warnings:
+            param_results = processing.param_results(
+                    self.es,
+                    exclude_none=False)
+            eq_(len(warnings), 1)
+            eq_(str(warnings[0].message),
+                str(DeprecationWarning(
+                    "The function 'param_results' has been "
+                    "renamed to'parameter_as_dict'.\n"
+                    "Pleas use the new function name to avoidproblems in the "
+                    "future.")))
+
 
         scalar_attributes = {
             'fixed': True,

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -133,8 +133,8 @@ class Parameter_Result_Tests:
                     "future.")
             eq_(repr(warnings[0].message),
                 repr(expectation),
-                "\n  Expected: \n---\n{!r}\n---".format(expectation) +
-                "\n  Got: \n---\n{!r}\n---".format(warnings[0].message))
+                "\n\nExpected: \n\n{!r}".format(expectation) +
+                "\n\nGot: \n\n{!r}".format(warnings[0].message))
 
 
         scalar_attributes = {

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -131,10 +131,10 @@ class Parameter_Result_Tests:
                     "renamed to'parameter_as_dict'.\n"
                     "Pleas use the new function name to avoidproblems in the "
                     "future.")
-            eq_(str(warnings[0].message),
-                str(expectation),
-                "\n  Expected: \n---\n{}\n---".format(expectation) +
-                "\n  Got: \n---\n{}\n---".format(warnings[0].message))
+            eq_(repr(warnings[0].message),
+                repr(expectation),
+                "\n  Expected: \n---\n{!r}\n---".format(expectation) +
+                "\n  Got: \n---\n{!r}\n---".format(warnings[0].message))
 
 
         scalar_attributes = {

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -111,7 +111,9 @@ class Parameter_Result_Tests:
         )
 
     def compatibility_test(self):
-        """This check is implemented to check whether the old name still works.
+        """ `param_results` still works but raises a `DeprecationWarning`.
+
+        This check is implemented to check whether the old name still works.
         `param_results` has been renamed to `parameter_as_dict`.
         Test and function can be removed with the next major release!
         """

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -121,13 +121,18 @@ class Parameter_Result_Tests:
             param_results = processing.param_results(
                     self.es,
                     exclude_none=False)
-            eq_(len(warnings), 1)
-            eq_(str(warnings[0].message),
-                str(DeprecationWarning(
+            eq_(len(warnings), 1,
+                    "\n  Expected a single warning to be issued."
+                    "\n  Got: {}".format(len(warnings)))
+            expectation = DeprecationWarning(
                     "The function 'param_results' has been "
                     "renamed to'parameter_as_dict'.\n"
                     "Pleas use the new function name to avoidproblems in the "
-                    "future.")))
+                    "future.")
+            eq_(str(warnings[0].message),
+                str(expectation),
+                "\n  Expected: \n---\n{}\n---".format(expectation) +
+                "\n  Got: \n---\n{}\n---".format(warnings[0].message))
 
 
         scalar_attributes = {


### PR DESCRIPTION
It's really simple. The tests weren't fully updated to take a renamed function into account and the resulting deprecation warning messed up the test output. The PR really only renames the old function call to the new one.