### PR TITLE
Improve annuity calculation in economics tool

### DIFF
--- a/oemof/tools/economics.py
+++ b/oemof/tools/economics.py
@@ -9,9 +9,6 @@ available from its original location oemof/oemof/tools/economics.py
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
-import logging
-
-
 def annuity(capex, n, wacc, u=None, cost_decrease=0):
     """Calculates the annuity of an initial investment 'capex', considering the 
     cost of capital 'wacc' during a project horizon 'n'
@@ -62,8 +59,7 @@ def annuity(capex, n, wacc, u=None, cost_decrease=0):
         
     if ((n < 1) or (wacc < 0 or wacc > 1) or (u < 1) or
             (cost_decrease < 0 or cost_decrease > 1)):
-        msg = 'Input arguments for annuity function out of bounds!'
-        logging.warning(msg)
+        raise ValueError('Input arguments for "annuity" out of bounds!')
 
     return (
         capex * (wacc*(1+wacc)**n) / ((1 + wacc)**n - 1) *

--- a/oemof/tools/economics.py
+++ b/oemof/tools/economics.py
@@ -13,16 +13,34 @@ SPDX-License-Identifier: GPL-3.0-or-later
 def annuity(capex, n, wacc, **kwargs):
     """Calculate the annuity.
 
+    In case of a single initial investment:
+
     annuity = capex * (wacc * (1 + wacc) ** n) / ((1 + wacc) ** n - 1)
+    
+    or in case of repeated investments at fixed intervals 'u'
+        with decreasing costs 'cost_decrease':
+
+    annuity = capex * (wacc * (1 + wacc) ** n) / ((1 + wacc) ** n - 1)*
+              ((1-((1-cost_decrease)/(1+wacc))**n)/
+              (1-((1-cost_decrease)/(1+wacc))**u)))
 
     Parameters
     ----------
     capex : float
-        Capital expenditure (NPV of investment)
+        Capital expenditure for first investment (NPV of investment)
     n : int
-        Number of years that the investment is used (economic lifetime)
+        Number of years investigated; might be an integer multiple of technical
+        lifetime (u) in case of repeated investments; in case of a single
+        investment n must equal u (economic lifetime)
     wacc : float
         Weighted average cost of capital
+    u : int
+        Number of years that a single investment is used, i.e. the technical
+        lifetime of a single investment
+    cost_decrease : float
+        Annual rate of cost_decrease for repeated investments; takes the value '0'
+        if not set otherwise, that is in case of a single investment or in case
+        of no cost decrease for repeated investments
 
     Returns
     -------
@@ -32,6 +50,6 @@ def annuity(capex, n, wacc, **kwargs):
     u  = kwargs.get('u', n)
     cost_decrease = kwargs.get('cost_decrease', 0)
 
-    return (capex * (wacc * (1 + wacc) ** n) / ((1 + wacc) ** n - 1)
-                    *((1-((1-cost_decrease)/(1+wacc))**n)/
+    return (capex * (wacc * (1 + wacc) ** n) / ((1 + wacc) ** n - 1)*
+                    ((1-((1-cost_decrease)/(1+wacc))**n)/
                     (1-((1-cost_decrease)/(1+wacc))**u)))

--- a/oemof/tools/economics.py
+++ b/oemof/tools/economics.py
@@ -9,6 +9,7 @@ available from its original location oemof/oemof/tools/economics.py
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
+import logging
 
 def annuity(capex, n, wacc, u=None, cost_decrease=0):
     """Calculates the annuity of an initial investment 'capex', considering the 
@@ -57,6 +58,11 @@ def annuity(capex, n, wacc, u=None, cost_decrease=0):
     """ 
     if u is None:
         u = n
+        
+    if ((n<1) or (wacc<0 or wacc>1) or (u<1) or 
+        (cost_decrease<0 or cost_decrease>1)):
+        msg = 'Input arguments for annuity function out of bounds!'
+        logging.warning(msg)
 
     return (
         capex * (wacc*(1+wacc)**n) / ((1 + wacc)**n - 1) *

--- a/oemof/tools/economics.py
+++ b/oemof/tools/economics.py
@@ -10,7 +10,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 """
 
 
-def annuity(capex, n, wacc):
+def annuity(capex, n, wacc, **kwargs):
     """Calculate the annuity.
 
     annuity = capex * (wacc * (1 + wacc) ** n) / ((1 + wacc) ** n - 1)
@@ -28,5 +28,10 @@ def annuity(capex, n, wacc):
     -------
     float : annuity
 
-    """
-    return capex * (wacc * (1 + wacc) ** n) / ((1 + wacc) ** n - 1)
+    """ 
+    u  = kwargs.get('u', n)
+    cost_decrease = kwargs.get('cost_decrease', 0)
+
+    return (capex * (wacc * (1 + wacc) ** n) / ((1 + wacc) ** n - 1)
+                    *((1-((1-cost_decrease)/(1+wacc))**n)/
+                    (1-((1-cost_decrease)/(1+wacc))**u)))

--- a/oemof/tools/economics.py
+++ b/oemof/tools/economics.py
@@ -10,7 +10,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 """
 
 
-def annuity(capex, n, wacc, **kwargs):
+def annuity(capex, n, wacc, u=None, cost_decrease=0):
     """Calculate the annuity.
 
     In case of a single initial investment:
@@ -47,9 +47,11 @@ def annuity(capex, n, wacc, **kwargs):
     float : annuity
 
     """ 
-    u  = kwargs.get('u', n)
-    cost_decrease = kwargs.get('cost_decrease', 0)
+    if u is None:
+        u = n
 
-    return (capex * (wacc * (1 + wacc) ** n) / ((1 + wacc) ** n - 1)*
-                    ((1-((1-cost_decrease)/(1+wacc))**n)/
-                    (1-((1-cost_decrease)/(1+wacc))**u)))
+    return (
+        capex * (wacc*(1+wacc)**n) / ((1 + wacc)**n - 1) *
+        (( 1 - ((1-cost_decrease)/(1+wacc))**n) /
+         ( 1 - ((1-cost_decrease)/(1+wacc))**u))
+        )

--- a/oemof/tools/economics.py
+++ b/oemof/tools/economics.py
@@ -11,6 +11,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
 
+
 def annuity(capex, n, wacc, u=None, cost_decrease=0):
     """Calculates the annuity of an initial investment 'capex', considering the 
     cost of capital 'wacc' during a project horizon 'n'
@@ -35,8 +36,8 @@ def annuity(capex, n, wacc, u=None, cost_decrease=0):
     Parameters
     ----------
     capex : float
-        Capital expenditure for first investment. Net Present Value (NPV) or Net
-        Present Cost (NPC) of investment
+        Capital expenditure for first investment. Net Present Value (NPV) or
+        Net Present Cost (NPC) of investment
     n : int
         Horizon of the analysis, or number of years the annuity wants to be 
         obtained for (n>=1)
@@ -59,13 +60,12 @@ def annuity(capex, n, wacc, u=None, cost_decrease=0):
     if u is None:
         u = n
         
-    if ((n<1) or (wacc<0 or wacc>1) or (u<1) or 
-        (cost_decrease<0 or cost_decrease>1)):
+    if ((n < 1) or (wacc < 0 or wacc > 1) or (u < 1) or
+            (cost_decrease < 0 or cost_decrease > 1)):
         msg = 'Input arguments for annuity function out of bounds!'
         logging.warning(msg)
 
     return (
         capex * (wacc*(1+wacc)**n) / ((1 + wacc)**n - 1) *
-        (( 1 - ((1-cost_decrease)/(1+wacc))**n) /
-         ( 1 - ((1-cost_decrease)/(1+wacc))**u))
-        )
+        ((1 - ((1-cost_decrease)/(1+wacc))**n) /
+         (1 - ((1-cost_decrease)/(1+wacc))**u)))

--- a/oemof/tools/economics.py
+++ b/oemof/tools/economics.py
@@ -11,41 +11,49 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 
 def annuity(capex, n, wacc, u=None, cost_decrease=0):
-    """Calculate the annuity.
+    """Calculates the annuity of an initial investment 'capex', considering the 
+    cost of capital 'wacc' during a project horizon 'n'
 
-    In case of a single initial investment:
+    In case of a single initial investment, the employed formula reads:
 
-    annuity = capex * (wacc * (1 + wacc) ** n) / ((1 + wacc) ** n - 1)
+    .. math::
+    annuity = capex \cdot \frac{(wacc \cdot (1+wacc)^n)}
+              {((1 + wacc)^n - 1)}
     
-    or in case of repeated investments at fixed intervals 'u'
-        with decreasing costs 'cost_decrease':
+    In case of repeated investments (due to replacements) at fixed intervals 
+    'u', the formula yields:
 
-    annuity = capex * (wacc * (1 + wacc) ** n) / ((1 + wacc) ** n - 1)*
-              ((1-((1-cost_decrease)/(1+wacc))**n)/
-              (1-((1-cost_decrease)/(1+wacc))**u)))
+    .. math::
+    annuity = capex \cdot \frac{(wacc \cdot (1+wacc)^n)}
+              {((1 + wacc)^n - 1)} \cdot \left( 
+              \frac{1 - \left( \frac{(1-cost\_decrease)}
+              {(1+wacc)} \right)^n}
+              {1 - \left( \frac{(1-cost\_decrease)}{(1+wacc)}
+              \right)^u} \right)
 
     Parameters
     ----------
     capex : float
-        Capital expenditure for first investment (NPV of investment)
+        Capital expenditure for first investment. Net Present Value (NPV) or Net
+        Present Cost (NPC) of investment
     n : int
-        Number of years investigated; might be an integer multiple of technical
-        lifetime (u) in case of repeated investments; in case of a single
-        investment n must equal u (economic lifetime)
+        Horizon of the analysis, or number of years the annuity wants to be 
+        obtained for (n>=1)
     wacc : float
-        Weighted average cost of capital
+        Weighted average cost of capital (0<wacc<1)
     u : int
-        Number of years that a single investment is used, i.e. the technical
-        lifetime of a single investment
+        Lifetime of the investigated investment. Might be smaller than the 
+        analysis horizon, 'n', meaning it will have to be replaced. 
+        Takes value 'n' if not specified otherwise (u>=1)
     cost_decrease : float
-        Annual rate of cost_decrease for repeated investments; takes the value '0'
-        if not set otherwise, that is in case of a single investment or in case
-        of no cost decrease for repeated investments
-
+        Annual rate of cost decrease (due to, e.g., price experience curve). 
+        This only influences the result for investments corresponding to 
+        replacements, whenever u<n. 
+        Takes value 0, if not specified otherwise (0<cost_decrease<1)
     Returns
     -------
-    float : annuity
-
+    float 
+        annuity
     """ 
     if u is None:
         u = n

--- a/oemof/tools/economics.py
+++ b/oemof/tools/economics.py
@@ -9,6 +9,7 @@ available from its original location oemof/oemof/tools/economics.py
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
+
 def annuity(capex, n, wacc, u=None, cost_decrease=0):
     """Calculates the annuity of an initial investment 'capex', considering the 
     cost of capital 'wacc' during a project horizon 'n'
@@ -59,7 +60,7 @@ def annuity(capex, n, wacc, u=None, cost_decrease=0):
         
     if ((n < 1) or (wacc < 0 or wacc > 1) or (u < 1) or
             (cost_decrease < 0 or cost_decrease > 1)):
-        raise ValueError('Input arguments for "annuity" out of bounds!')
+        raise ValueError("Input arguments for 'annuity' out of bounds!")
 
     return (
         capex * (wacc*(1+wacc)**n) / ((1 + wacc)**n - 1) *

--- a/tests/tool_tests.py
+++ b/tests/tool_tests.py
@@ -35,3 +35,6 @@ def test_logger():
 
 def test_economics():
     ok_(round(economics.annuity(1000, 10, 0.1)) == 163)
+    ok_(round(economics.annuity(capex=1000, wacc=0.1, n=10, u=5)) == 264)
+    ok_(round(economics.annuity(1000, 10, 0.1, u=5, cost_decrease=0.1)) == 222)
+

--- a/tests/tool_tests.py
+++ b/tests/tool_tests.py
@@ -33,7 +33,8 @@ def test_logger():
     ok_(os.path.isfile(filepath))
 
 
-def test_economics():
+def test_annuity():
+    """Test annuity function of economics tool."""
     ok_(round(economics.annuity(1000, 10, 0.1)) == 163)
     ok_(round(economics.annuity(capex=1000, wacc=0.1, n=10, u=5)) == 264)
     ok_(round(economics.annuity(1000, 10, 0.1, u=5, cost_decrease=0.1)) == 222)

--- a/tests/tool_tests.py
+++ b/tests/tool_tests.py
@@ -11,7 +11,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
 
-from nose.tools import ok_
+from nose.tools import ok_, assert_raises_regexp
 
 from oemof.tools import logger
 from oemof.tools import helpers
@@ -39,3 +39,13 @@ def test_annuity():
     ok_(round(economics.annuity(capex=1000, wacc=0.1, n=10, u=5)) == 264)
     ok_(round(economics.annuity(1000, 10, 0.1, u=5, cost_decrease=0.1)) == 222)
 
+
+def test_annuity_exceptions():
+    """Test out-of-bounds-error of the annuity tool."""
+    msg = "Input arguments for 'annuity' out of bounds!"
+    assert_raises_regexp(ValueError, msg, economics.annuity, 1000, 10, 2)
+    assert_raises_regexp(ValueError, msg, economics.annuity, 1000, 0.5, 1)
+    assert_raises_regexp(
+        ValueError, msg, economics.annuity, 1000, 10, 0.1, u=0.3)
+    assert_raises_regexp(
+        ValueError, msg, economics.annuity, 1000, 10, 0.1, cost_decrease=-1)


### PR DESCRIPTION
* Describe your pull request as transparent as possible:
The annuity function in the economics tool has been supplemented by possible multiple investment and cost decreases. Both parameters  ('u', 'cost_decrease') can be set optionally. If not set, the function works as before.

* Related issues:
The function was suggested by a user on the last user meeting: https://github.com/baumconsult/gridcon/blob/master/economics_BAUM_171221.py
This is now the output of the working group from the last developer meeting.
This issue #431 might also be related.
