### PR TITLE
Increase test coverage of solph.models module

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,4 @@
 [run]
 omit =
     *datapackage*
-    custom.py
+    *custom*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,4 @@
 [run]
-omit = *datapackage*
+omit =
+    *datapackage*
+    custom.py

--- a/doc/whatsnew/v0-3-0.rst
+++ b/doc/whatsnew/v0-3-0.rst
@@ -40,7 +40,11 @@ Bug fixes
 Testing
 #######
 
-* something
+* Automatic test coverage control was implemented. Now a PR will not be
+    accepted if it decreases the test coverage.
+* Test coverage was increased to over 90%. A badge was added to the
+    `oemof github page <https://github.com/oemof/oemof>`_ that shows the
+    actual test coverage.
 
 Other changes
 #############

--- a/doc/whatsnew/v0-3-0.rst
+++ b/doc/whatsnew/v0-3-0.rst
@@ -30,7 +30,12 @@ Known issues
 Bug fixes
 #########
 
-* something
+* The timeincrement attribute of the model is not set to one anymore.
+    In earlier versions the timeincrement was set to one by default. This was a
+    problem if a wrong time index was passed. In that case the timeincrement
+    was set to one without a warning. Now an error is raised if no
+    timeincrement or valid time index is found
+    (`Issue #549 <https://github.com/oemof/oemof/issues/549>`_).
 
 Testing
 #######

--- a/doc/whatsnew/v0-3-0.rst
+++ b/doc/whatsnew/v0-3-0.rst
@@ -5,12 +5,17 @@ v0.3.0 (January ??, 2019)
 API changes
 ###########
 
-* something
+* The ``param_results`` function does not exist anymore. It has been renamed to
+    ``parameter_as_dict`` a time ago but the old name still worked for a while
+    along with a ``FutureWarning``
+    (`Issue #537 <https://github.com/oemof/oemof/issues/537>`_).
 
 New features
 ############
 
-* something
+* Namedtuples and tuples as labels work now without problems. This makes it
+    much easier to find objects and results in large energy systems
+    (`Issue #507 <https://github.com/oemof/oemof/issues/507>`_).
 
 New components
 ##############

--- a/oemof/energy_system.py
+++ b/oemof/energy_system.py
@@ -121,9 +121,7 @@ class EnergySystem:
                 g(e, self.groups)
         self.results = kwargs.get('results')
 
-        self.timeindex = kwargs.get('timeindex',
-                                    pd.date_range(start=pd.to_datetime('today'),
-                                                  periods=1, freq='H'))
+        self.timeindex = kwargs.get('timeindex')
 
         self.temporal = kwargs.get('temporal')
 

--- a/oemof/energy_system.py
+++ b/oemof/energy_system.py
@@ -14,7 +14,6 @@ from pickle import UnpicklingError
 import logging
 import os
 
-import pandas as pd
 import dill as pickle
 
 from oemof.groupings import DEFAULT as BY_UID, Grouping, Nodes

--- a/oemof/energy_system.py
+++ b/oemof/energy_system.py
@@ -130,14 +130,6 @@ class EnergySystem:
             g(entity, groups)
         return groups
 
-    try:
-        from .tools.datapackage import deserialize_energy_system
-        from_datapackage = classmethod(deserialize_energy_system)
-    except ImportError as e:
-        @classmethod
-        def from_datapackage(cls, *args, **kwargs):
-            raise e
-
     def _add(self, entity):
         self.entities.append(entity)
         self._groups = partial(self._regroup, entity, self.groups,

--- a/oemof/solph/custom.py
+++ b/oemof/solph/custom.py
@@ -25,6 +25,8 @@ class ElectricalBus(Bus):
     Bus is used in combination with ElectricalLine objects for linear optimal
     power flow (lopf) simulations.
 
+    Note: This component is experimental. Use it with care.
+
     Notes
     -----
     The following sets, variables, constraints and objective parts are created
@@ -50,6 +52,8 @@ class ElectricalLine(Transformer):
     ----------
     reactance : float or array of floats
         Reactance of the line to be modelled
+
+    Note: This component is experimental. Use it with care.
 
     Notes
     -----
@@ -116,6 +120,7 @@ class ElectricalLineBlock(SimpleBlock):
     r"""Block for the linear relation of nodes with type
     class:`.ElectricalLine`
 
+    Note: This component is experimental. Use it with care.
 
     **The following constraints are created:**
 
@@ -220,6 +225,8 @@ class Link(Transformer):
         The dictionary values can either be a scalar or a sequence with length
         of time horizon for simulation.
 
+    Note: This component is experimental. Use it with care.
+
     Notes
     -----
     The sets, variables, constraints and objective parts are created
@@ -263,9 +270,12 @@ class Link(Transformer):
     def constraint_group(self):
         return LinkBlock
 
+
 class LinkBlock(SimpleBlock):
     r"""Block for the relation of nodes with type
     :class:`~oemof.solph.custom.Link`
+
+    Note: This component is experimental. Use it with care.
 
     **The following constraints are created:**
 
@@ -346,6 +356,8 @@ class GenericCAES(Transformer):
         Dictionary with key-value-pair of `oemof.Bus` and `oemof.Flow` object
         for the electrical output.
 
+    Note: This component is experimental. Use it with care.
+
     Notes
     -----
     The following sets, variables, constraints and objective parts are created
@@ -412,7 +424,11 @@ class GenericCAES(Transformer):
 
 
 class GenericCAESBlock(SimpleBlock):
-    """Block for nodes of class:`.GenericCAES`."""
+    """Block for nodes of class:`.GenericCAES`.
+
+    Note: This component is experimental. Use it with care.
+
+    """
 
     CONSTRAINT_GROUP = True
 
@@ -710,6 +726,8 @@ class OffsetTransformer(Transformer):
         The dictionary values can either be a scalar or a sequence with length
         of time horizon for simulation.
 
+    Note: This component is experimental. Use it with care.
+
     Notes
     -----
     The sets, variables, constraints and objective parts are created
@@ -754,6 +772,8 @@ class OffsetTransformer(Transformer):
 class OffsetTransformerBlock(SimpleBlock):
     r"""Block for the relation of nodes with type
     :class:`~oemof.solph.custom.OffsetTransformer`
+    
+    Note: This component is experimental. Use it with care.
 
     **The following constraints are created:**
 

--- a/oemof/solph/models.py
+++ b/oemof/solph/models.py
@@ -48,19 +48,19 @@ class BaseModel(po.ConcreteModel):
         # ########################  Arguments #################################
 
         self.name = kwargs.get('name', type(self).__name__)
-
         self.es = energysystem
+        self.timeincrement = sequence(kwargs.get('timeincrement', None))
 
-        try:
-            self.timeincrement = sequence(self.es.timeindex.freq.nanos / 3.6e12)
-        except AttributeError:
-            logging.warning(
-                'Could not get timeincrement from pd.DateTimeIndex! ' +
-                'To avoid this warning, make sure the `freq` attribute of ' +
-                'your timeindex is not None. Setting timeincrement to 1...')
-            self.timeincrement = sequence(1)
-
-
+        if self.timeincrement[0] is None:
+            try:
+                self.timeincrement = sequence(
+                    self.es.timeindex.freq.nanos / 3.6e12)
+            except AttributeError:
+                msg = ("No valid time increment found. Please pass a valid "
+                       "timeincremet parameter or pass an EnergySystem with "
+                       "a valid time index. Please note that a valid time"
+                       "index need to have a 'freq' attribute.")
+                raise AttributeError(msg)
 
         self.objective_weighting = kwargs.get('objective_weighting',
                                               self.timeincrement)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,12 +9,15 @@ available from its original location oemof/tests/basic_tests.py
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
+import pandas as pd
 from oemof import solph
 from nose.tools import eq_, raises
 
 
 def test_timeincrement_with_valid_timeindex():
-    es = solph.EnergySystem()
+    datetimeindex = pd.date_range('1/1/2012', periods=1, freq='H')
+    es = solph.EnergySystem(timeindex=datetimeindex)
+    print(es.timeindex.freq)
     m = solph.models.BaseModel(es)
     eq_(m.timeincrement[0], 1)
     eq_(es.timeindex.freq.nanos / 3.6e12, 1)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -
+
+"""Basic tests.
+
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted
+by the contributors recorded in the version control history of the file,
+available from its original location oemof/tests/basic_tests.py
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+from oemof import solph
+from nose.tools import eq_, raises
+
+
+def test_timeincrement_with_valid_timeindex():
+    es = solph.EnergySystem()
+    m = solph.models.BaseModel(es)
+    eq_(m.timeincrement[0], 1)
+    eq_(es.timeindex.freq.nanos / 3.6e12, 1)
+
+
+@raises(AttributeError)
+def test_timeincrement_with_non_valid_timeindex():
+    es = solph.EnergySystem(timeindex=4)
+    solph.models.BaseModel(es)
+
+
+def test_timeincrement_value():
+    es = solph.EnergySystem(timeindex=4)
+    m = solph.models.BaseModel(es, timeincrement=3)
+    eq_(m.timeincrement[0], 3)
+
+
+def test_timeincrement_list():
+    es = solph.EnergySystem(timeindex=4)
+    m = solph.models.BaseModel(es, timeincrement=[0, 1, 2, 3])
+    eq_(m.timeincrement[3], 3)

--- a/tests/test_network_classes.py
+++ b/tests/test_network_classes.py
@@ -12,6 +12,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 from traceback import format_exception_only as feo
 from nose.tools import assert_raises, eq_, ok_
 import warnings
+import pandas as pd
 
 from oemof.energy_system import EnergySystem as ES
 from oemof.network import Bus, Edge, Node, Transformer
@@ -258,7 +259,8 @@ class EnergySystem_Nodes_Integration_Tests:
 
 
 def test_depreciated_graph_call():
-    es = ES()
+    datetimeindex = pd.date_range('1/1/2012', periods=1, freq='H')
+    es = ES(timeindex=datetimeindex)
     om = Model(energysystem=es)
     warnings.filterwarnings('ignore', category=FutureWarning)
     graph.create_nx_graph(optimization_model=om)

--- a/tests/test_scripts/test_solph/test_simple_model/test_simple_dispatch_one.py
+++ b/tests/test_scripts/test_solph/test_simple_model/test_simple_dispatch_one.py
@@ -68,15 +68,14 @@ def test_dispatch_one_time_step(solver='cbc', periods=1):
                             conversion_factors={
                                         bel: 1/3, b_heat_source: (cop-1)/cop})
 
-    datetimeindex = pd.date_range('1/1/2012', periods=periods, freq='H')
-    energysystem = EnergySystem(timeindex=datetimeindex)
+    energysystem = EnergySystem(timeindex=[1])
     energysystem.add(bgas, bel, bth, excess_el, wind, demand_el, demand_th,
                      pp_chp, b_heat_source, heat_source, heat_pump)
 
     # ################################ optimization ###########################
 
     # create optimization model based on energy_system
-    optimization_model = Model(energysystem=energysystem)
+    optimization_model = Model(energysystem=energysystem, timeincrement=1)
 
     # solve problem
     optimization_model.solve(solver=solver)


### PR DESCRIPTION
There are some special conditions in this module and we should remove them or test them.

Furthermore `custom.py` is removed from the test coverage check, because we announced that it is not necessary to write tests for the custom components but we should warn users about this.