### PR TITLE
Remove __setitem__ because this is not intended

### DIFF
--- a/oemof/energy_system.py
+++ b/oemof/energy_system.py
@@ -11,16 +11,14 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 from functools import partial
 from pickle import UnpicklingError
-import collections.abc as cabc
 import logging
 import os
-import re
 
 import pandas as pd
 import dill as pickle
 
 from oemof.groupings import DEFAULT as BY_UID, Grouping, Nodes
-from oemof.network import Bus, Component
+from oemof.network import Bus
 
 
 class EnergySystem:
@@ -135,7 +133,6 @@ class EnergySystem:
             g(entity, groups)
         return groups
 
-
     try:
         from .tools.datapackage import deserialize_energy_system
         from_datapackage = classmethod(deserialize_energy_system)
@@ -143,7 +140,6 @@ class EnergySystem:
         @classmethod
         def from_datapackage(cls, *args, **kwargs):
             raise e
-
 
     def _add(self, entity):
         self.entities.append(entity)
@@ -228,7 +224,6 @@ class EnergySystem:
                         "https://github.com/oemof/oemof/issues\n\n  "
                         "or comment on it if it already exists.")
             raise e
-
 
         msg = ('Attributes restored from: {0}'.format(os.path.join(
             dpath, filename)))

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -452,8 +452,6 @@ class Bus(SimpleBlock):
         \sum_{o \in OUTPUTS(n)} flow(n, o, t) \cdot \tau, \\
         \forall n \in \textrm{BUSES},
         \forall t \in \textrm{TIMESTEPS}.
-
-    Hallo
     """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/oemof/solph/plumbing.py
+++ b/oemof/solph/plumbing.py
@@ -58,13 +58,17 @@ class _Sequence(UserList):
     >>> s = _Sequence(default=42)
     >>> len(s)
     0
+    >>> s[1]
+    42
     >>> s[2]
     42
     >>> len(s)
     3
-    >>> s[0] = 23
     >>> s
-    [23, 42, 42]
+    [42, 42, 42]
+    >>> s[8]
+    42
+
 
     """
     def __init__(self, *args, **kwargs):
@@ -75,37 +79,16 @@ class _Sequence(UserList):
 
     def __getitem__(self, key):
         self.highest_index = max(self.highest_index, key)
-        if not self.default_changed:
-            return self.default
-        try:
-            return self.data[key]
-        except IndexError:
-            self.data.extend([self.default] * (key - len(self.data) + 1))
-            return self.data[key]
-
-    def __setitem__(self, key, value):
-        if not self.default_changed:
-            self.default_changed = True
-            self.__init_list()
-        try:
-            self.data[key] = value
-        except IndexError:
-            self.data.extend([self.default] * (key - len(self.data) + 1))
-            self.data[key] = value
+        return self.default
 
     def __init_list(self):
         self.data = [self.default] * (self.highest_index + 1)
 
     def __repr__(self):
-        if self.default_changed:
-            return super(_Sequence, self).__repr__()
         return str([i for i in self])
 
     def __len__(self):
         return max(len(self.data), self.highest_index + 1)
 
     def __iter__(self):
-        if self.default_changed:
-            return super(_Sequence, self).__iter__()
-        else:
-            return repeat(self.default, self.highest_index + 1)
+        return repeat(self.default, self.highest_index + 1)


### PR DESCRIPTION
Setting single values of a sequence leads to unwanted behaviour (e.g. never ending loop). Therefore, I think it is better to allow only the full replacement of a sequence but not the change of single values.

@oemof/oemof-developer-group : Does anybody needs this method???