### PR TITLE
Revise results handling of the model

### DIFF
--- a/oemof/solph/models.py
+++ b/oemof/solph/models.py
@@ -184,8 +184,8 @@ class BaseModel(po.ConcreteModel):
         results = opt.solve(self, **solve_kwargs)
 
         status = results["Solver"][0]["Status"].key
-        termination_condition = \
-            results["Solver"][0]["Termination condition"].key
+        termination_condition = (
+            results["Solver"][0]["Termination condition"].key)
 
         if status == "ok" and termination_condition == "optimal":
             logging.info("Optimization successful...")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -
+
+"""Test the created constraints against approved constraints.
+
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted
+by the contributors recorded in the version control history of the file,
+available from its original location oemof/tests/test_network_classes.py
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+import pandas as pd
+from oemof.solph import Sink, Source, Bus, Flow, Model, EnergySystem
+
+
+def test_dispatch_example(solver='cbc'):
+    """Create an energy system and optimize the dispatch at least costs."""
+    datetimeindex = pd.date_range('1/1/2012', periods=3, freq='H')
+    es = EnergySystem(timeindex=datetimeindex)
+    
+    bel = Bus(label='b_el')
+    es.add(bel)
+    es.add(Source(label='src', outputs={bel: Flow(actual_value=[1, 2, 3],
+           nominal_value=1, fixed=True)}))
+
+    es.add(Sink(label='demand_elec', inputs={bel: Flow(nominal_value=1,
+                actual_value=[1, 2, 3], fixed=True)}))
+
+    optimization_model = Model(energysystem=es)
+    optimization_model.solve(solver=solver)
+
+    # write back results from optimization object to energysystem
+    optimization_model.results()


### PR DESCRIPTION
At the moment the results handling is confusing:

1. Is it still necessary to call  `self.solutions.load_from(results)`?
2. I think we should distinguish just two or three termination conditions.
      1. Everything is fine. Results can be written
      2. Something not optimal, but there are some results that can be processed (Does this case exist?)
      3. No solution -> no results
3. What shall we do with the results?
    1. Leave them where they are and let the user call `results = outputlib.processing.results(model)`
    2. Write them to the EnergySystem results attribute.
    3. Return them (`results = model.solve(...)`) - see (4).
4. What shall we do with the meta results return by pyomos `solve` method?
    1. Leave them where they are an let the user call `results = outputlib.processing.meta_results(model)`
    2. Write them to an EnergySystem attribute?
    3. Return them (`meta_results = model.solve(...)`) - see (3).
5. I can create small test models for 2.I. and 2.III. but I have no experience with 2.II.. Can anybody help.

@oemof/oemof-developer-group I need a feedback:exclamation: 