### PR TITLE
Features/remove deprecated attribute

### DIFF
--- a/oemof/graph.py
+++ b/oemof/graph.py
@@ -10,11 +10,9 @@ SPDX-License-Identifier: GPL-3.0-or-later
 """
 
 import networkx as nx
-import warnings
 
 
-def create_nx_graph(energy_system=None, optimization_model=None,
-                    remove_nodes=None, filename=None,
+def create_nx_graph(energy_system=None, remove_nodes=None, filename=None,
                     remove_nodes_with_substrings=None, remove_edges=None):
     """
     Create a `networkx.DiGraph` for the passed energy system and plot it.
@@ -94,13 +92,6 @@ def create_nx_graph(energy_system=None, optimization_model=None,
     """
     # construct graph from nodes and flows
     grph = nx.DiGraph()
-
-    # Get energy_system from Model
-    if energy_system is None:
-        msg = ("\nThe optimisation_model attribute will be removed, pass the "
-               "energy system instead.")
-        warnings.warn(msg, FutureWarning)
-        energy_system = optimization_model.es
 
     # add nodes
     for n in energy_system.nodes:

--- a/tests/test_network_classes.py
+++ b/tests/test_network_classes.py
@@ -255,10 +255,3 @@ class EnergySystem_Nodes_Integration_Tests:
         eq_(self.es.entities[1], b2)
         t1 = Transformer(label='<TF1>', inputs=[b1], outputs=[b2])
         ok_(t1 in self.es.entities)
-
-
-def test_depreciated_graph_call():
-    es = ES()
-    om = Model(energysystem=es)
-    warnings.filterwarnings('ignore', category=FutureWarning)
-    graph.create_nx_graph(optimization_model=om)

--- a/tests/test_network_classes.py
+++ b/tests/test_network_classes.py
@@ -11,12 +11,9 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 from traceback import format_exception_only as feo
 from nose.tools import assert_raises, eq_, ok_
-import warnings
 
 from oemof.energy_system import EnergySystem as ES
 from oemof.network import Bus, Edge, Node, Transformer
-from oemof import graph
-from oemof.solph import Model
 
 
 class Node_Tests:


### PR DESCRIPTION
 In an older version it was possible to pass the`Model` OR(!) the `EnergySystem`. It does not make sense to pass the `EnergySystem` to the `Model`, and then the `Model` to the create_nx_graph function just to get the `EnergySystem` from the `Model`.