### PR TITLE
Add subnodes list when adding objects to energy system instance

### DIFF
--- a/oemof/energy_system.py
+++ b/oemof/energy_system.py
@@ -151,6 +151,8 @@ class EnergySystem:
         """
         for n in nodes:
             self._add(n)
+            if hasattr(n, 'subnodes'):
+                self.add(*n.subnodes)
 
     @property
     def groups(self):


### PR DESCRIPTION
**Describe your pull request as transparent as possible**
  * Add subnodes (in list or array like objects of the energy system) to the energy system automatically. 
  
Useful functionality for individual modelling based on oemof solph base classes like in oemof-

