### PR TITLE
Features/switch

### DIFF
--- a/oemof/solph/custom.py
+++ b/oemof/solph/custom.py
@@ -330,7 +330,7 @@ class SimpleSwitch(Transformer):
     Parameters
     ----------
     inputs : dict
-        Dictionary mapping output nodes to corresponding outflows.
+        Dictionary mapping input nodes to corresponding inflows.
         The Flows have to have a defined 'nominal_value'.
     outputs: dict
         (see inputs, same number of entries as inputs)

--- a/oemof/solph/custom.py
+++ b/oemof/solph/custom.py
@@ -396,6 +396,14 @@ class SwitchBlock(SimpleBlock):
 
         m = self.parent_block()
 
+        self.SWITCHES = Set(initialize=[n for n in group])
+
+        self.SWITCH_CONNECTIONS = Set(
+            initialize=[f for s in group for f in s.conversion_factors])
+
+        self.status = Var(self.SWITCHES, self.SWITCH_CONNECTIONS, m.TIMESTEPS,
+                          within=Binary)
+
         all_conversions = {}
         for n in group:
             all_conversions[n] = {

--- a/oemof/solph/custom.py
+++ b/oemof/solph/custom.py
@@ -414,7 +414,7 @@ class SwitchBlock(SimpleBlock):
                 for n, conversion in all_conversions.items():
                     for (i, o), c in conversion.items():
                         try:
-                            expr = (m.flow[n, 0, t] == c[t] * m.flow[i, n, t])
+                            expr = (m.flow[n, o, t] == c[t] * m.flow[i, n, t])
                         except ValueError:
                             raise ValueError(
                                 "Error in constraint creation",

--- a/tests/test_scripts/test_solph/test_switch/test_switch.py
+++ b/tests/test_scripts/test_solph/test_switch/test_switch.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""
+Example that illustrates how to use custom component `Switch` can be used.
+
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted
+by the contributors recorded in the version control history of the file,
+available from its original location
+oemof/tests/test_scripts/test_solph/test_generic_caes/test_generic_caes.py
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+from nose.tools import eq_
+import os
+import pprint
+import pandas as pd
+import oemof.solph as solph
+from oemof.network import Node
+from oemof.outputlib import processing, views
+from oemof.solph.custom import Link, Switch
+
+
+def test_switch():
+    # select periods
+    periods = 4
+
+    # create an energy system
+    idx = pd.date_range('1/1/2017', periods=periods, freq='H')
+    es = solph.EnergySystem(timeindex=idx)
+    Node.registry = es
+
+    b_int = solph.Bus(label='b_int')
+    b_ext = solph.Bus(label='b_ext')
+
+    d_int = solph.Sink(label="d_int",
+                       inputs={b_int: solph.Flow(
+                           nominal_value=4, fixed=True,
+                           actual_value=[1, 0, 1, 0])})
+    d_ext = solph.Sink(label="d_ext",
+                       inputs={b_ext: solph.Flow(
+                           nominal_value=1)})
+
+    s_int = solph.Source(label="s_int",
+                         outputs={b_int: solph.Flow(
+                             nominal_value=1, fixed=True,
+                             actual_value=[1, 1, 1, 0])})
+    s_ext = solph.Source(label="s_ext",
+                         outputs={b_ext: solph.Flow(
+                             variable_costs=3)})
+
+    switch = Switch(
+        label="switch",
+        inputs={b_int: solph.Flow(), b_ext: solph.Flow()},
+        outputs={b_ext: solph.Flow(variable_costs=-1), b_int: solph.Flow()},
+        conversion_factors={(b_int, b_ext): 0.5,
+                            (b_ext, b_int): 1})
+
+
+    # create an optimization problem and solve it
+    om = solph.Model(es)
+
+    # solve model
+    om.solve(solver='cbc')
+
+    # create result object
+    results = processing.results(om)
+
+    data = views.node(
+        results, 'switch', keep_none_type=True
+    )['sequences']
+
+    pprint.pprint(data.to_dict())
+
+
+if __name__ == "__main__":
+    test_switch()

--- a/tests/test_scripts/test_solph/test_switch/test_switch.py
+++ b/tests/test_scripts/test_solph/test_switch/test_switch.py
@@ -10,17 +10,16 @@ oemof/tests/test_scripts/test_solph/test_generic_caes/test_generic_caes.py
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
-from nose.tools import eq_
-import os
-import pprint
+from nose.tools import eq_, ok_
+import numpy as np
 import pandas as pd
 import oemof.solph as solph
 from oemof.network import Node
-from oemof.outputlib import processing, views
-from oemof.solph.custom import Link, Switch
+from oemof.outputlib import processing
+from oemof.solph.custom import SimpleSwitch
 
 
-def test_switch():
+def _setup_switch(connections):
     # select periods
     periods = 4
 
@@ -34,8 +33,8 @@ def test_switch():
 
     d_int = solph.Sink(label="d_int",
                        inputs={b_int: solph.Flow(
-                           nominal_value=4, fixed=True,
-                           actual_value=[1, 0, 1, 0])})
+                           nominal_value=1, fixed=True,
+                           actual_value=[1, 0, 1, 1])})
     d_ext = solph.Sink(label="d_ext",
                        inputs={b_ext: solph.Flow(
                            nominal_value=1)})
@@ -46,15 +45,19 @@ def test_switch():
                              actual_value=[1, 1, 1, 0])})
     s_ext = solph.Source(label="s_ext",
                          outputs={b_ext: solph.Flow(
+                             maximum_value=1,
                              variable_costs=3)})
 
-    switch = Switch(
+    switch = SimpleSwitch(
         label="switch",
-        inputs={b_int: solph.Flow(), b_ext: solph.Flow()},
-        outputs={b_ext: solph.Flow(variable_costs=-1), b_int: solph.Flow()},
-        conversion_factors={(b_int, b_ext): 0.5,
-                            (b_ext, b_int): 1})
-
+        inputs={b_int: solph.Flow(nominal_value=10),
+                b_ext: solph.Flow(nominal_value=10)},
+        outputs={b_ext: solph.Flow(variable_costs=-1,
+                                   nominal_value=10),
+                 b_int: solph.Flow(nominal_value=10)},
+        conversion_factors={(b_int, b_ext): 1,
+                            (b_ext, b_int): 1},
+        concurrent_connections=connections)
 
     # create an optimization problem and solve it
     om = solph.Model(es)
@@ -63,13 +66,22 @@ def test_switch():
     om.solve(solver='cbc')
 
     # create result object
-    results = processing.results(om)
+    return processing.results(om)[(switch, b_int)]["sequences"].values
 
-    data = views.node(
-        results, 'switch', keep_none_type=True
-    )['sequences']
 
-    pprint.pprint(data.to_dict())
+def test_switch():
+    # With one allowed connection, the example allows export
+    # only for energy from the internal Source.
+    # So, there will be only import when needed.
+    result1 = _setup_switch(1)
+    correct1 = np.ndarray(shape=(4, 1), buffer=np.array([0., 0., 0., 1.]))
+    ok_(np.alltrue(result1 == correct1))
+
+    # With two allowed connections, an import->export loop will be profitable.
+    # So, all free export capacity is used by importing.
+    result2 = _setup_switch(2)
+    correct2 = np.ndarray(shape=(4, 1), buffer=np.array([10., 9., 10., 10.]))
+    ok_(np.alltrue(result2 == correct2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Implements custom component `SimpleSwitch`
  * Class allows to connect M inputs with M outputs.
  * N<M of these connections are active at the same time. (N defaults to 1.)
  * Links between inputs and outputs (using `conversion_factors`) are obligatory.
  * All connected flows have to have a `nominal_value`.
* Implements #567.
* Originally, I wanted to create M inputs to N outputs with O arbitrary connections. But branching energy flows inside a switch seemed to complicate things also for users. To emphasise that this is not the simple variant, the component is called `SimpleSwitch`.
* The unit test is more of an example on how to use the switch. Custom components do not need unit tests, do they? (The API would benefit from some refinement, still, it is useful in its current status.)
