### PR TITLE
Raise an AttributeError if deprecated attribute is used

### DIFF
--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -152,6 +152,19 @@ class GenericStorage(network.Transformer):
         if self._invest_group is True:
             self._check_invest_attributes()
 
+        # Check for old parameter names.
+        rename_parameters = [
+            ('nominal_capacity', 'nominal_storage_capacity'),
+            ('initial_capacity', 'initial_storage_level'),
+            ('capacity_loss', 'loss_rate'),
+            ('capacity_min', 'min_storage_level'),
+            ('capacity_max', 'max_storage_level')]
+        for parameter in rename_parameters:
+            if kwargs.get(parameter[0]) is not None:
+                msg = "The attribute '{0}' has been renamed to '{1}'.".format(
+                    parameter[0], parameter[1])
+                raise AttributeError(msg)
+
     def _set_flows(self):
         for flow in self.inputs.values():
             if (self.invest_relation_input_capacity is not None and

--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -153,7 +153,7 @@ class GenericStorage(network.Transformer):
             self._check_invest_attributes()
 
         # Check for old parameter names. This is a temporary fix and should
-        # be removed once a general solution is found
+        # be removed once a general solution is found.
         # Todo: https://github.com/oemof/oemof/issues/560
         rename_parameters = [
             ('nominal_capacity', 'nominal_storage_capacity'),

--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -155,13 +155,13 @@ class GenericStorage(network.Transformer):
         # Check for old parameter names. This is a temporary fix and should
         # be removed once a general solution is found.
         # TODO: https://github.com/oemof/oemof/issues/560
-        rename_parameters = [
+        renamed_parameters = [
             ('nominal_capacity', 'nominal_storage_capacity'),
             ('initial_capacity', 'initial_storage_level'),
             ('capacity_loss', 'loss_rate'),
             ('capacity_min', 'min_storage_level'),
             ('capacity_max', 'max_storage_level')]
-        for parameter in rename_parameters:
+        for parameter in renamed_parameters:
             if kwargs.get(parameter[0]) is not None:
                 msg = "The attribute '{0}' has been renamed to '{1}'.".format(
                     parameter[0], parameter[1])

--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -161,11 +161,23 @@ class GenericStorage(network.Transformer):
             ('capacity_loss', 'loss_rate'),
             ('capacity_min', 'min_storage_level'),
             ('capacity_max', 'max_storage_level')]
-        for parameter in renamed_parameters:
-            if kwargs.get(parameter[0]) is not None:
-                msg = "The attribute '{0}' has been renamed to '{1}'.".format(
-                    parameter[0], parameter[1])
-                raise AttributeError(msg)
+        messages = [
+            "`{0}` to `{1}`".format(old_name, new_name)
+            for old_name, new_name in renamed_parameters
+            if old_name in kwargs
+        ]
+        if messages:
+            message = (
+                "The following attributes have been renamed from v0.2 to v0.3:"
+                "\n\n  {}\n\n"
+                "You are using the old names as parameters, thus setting "
+                "deprecated\n"
+                "attributes, which is not what you might have intended.\n"
+                "Use the new names, or, if you know what you're doing, set "
+                "these\n"
+                "attributes explicitly after construction instead."
+            )
+            raise AttributeError(message.format("\n  ".join(messages)))
 
     def _set_flows(self):
         for flow in self.inputs.values():

--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -154,7 +154,7 @@ class GenericStorage(network.Transformer):
 
         # Check for old parameter names. This is a temporary fix and should
         # be removed once a general solution is found.
-        # Todo: https://github.com/oemof/oemof/issues/560
+        # TODO: https://github.com/oemof/oemof/issues/560
         rename_parameters = [
             ('nominal_capacity', 'nominal_storage_capacity'),
             ('initial_capacity', 'initial_storage_level'),

--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -152,7 +152,9 @@ class GenericStorage(network.Transformer):
         if self._invest_group is True:
             self._check_invest_attributes()
 
-        # Check for old parameter names.
+        # Check for old parameter names. This is a temporary fix and should
+        # be removed once a general solution is found
+        # Todo: https://github.com/oemof/oemof/issues/560
         rename_parameters = [
             ('nominal_capacity', 'nominal_storage_capacity'),
             ('initial_capacity', 'initial_storage_level'),

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -59,6 +59,58 @@ def test_generic_storage_3():
         inflow_conversion_factor=1, outflow_conversion_factor=0.8)
 
 
+def test_generic_storage_with_old_parameters():
+    bel = solph.Bus()
+    with tools.assert_raises_regexp(
+            AttributeError,
+            ("The attribute 'initial_capacity' has been renamed to "
+             "'initial_storage_level'.")):
+        solph.components.GenericStorage(
+            label='storage5',
+            nominal_storage_capacity=45,
+            inputs={bel: solph.Flow(nominal_value=23, variable_costs=10e10)},
+            outputs={bel: solph.Flow(nominal_value=7.5, variable_costs=10e10)},
+            initial_capacity=0)
+    with tools.assert_raises_regexp(
+            AttributeError,
+            "The attribute 'capacity_loss' has been renamed to 'loss_rate'"):
+        solph.components.GenericStorage(
+            label='storage6',
+            nominal_storage_capacity=45,
+            inputs={bel: solph.Flow(nominal_value=23, variable_costs=10e10)},
+            outputs={bel: solph.Flow(nominal_value=7.5, variable_costs=10e10)},
+            capacity_loss=0)
+    with tools.assert_raises_regexp(
+            AttributeError,
+            ("The attribute 'capacity_min' has been renamed to"
+             " 'min_storage_level'")):
+        solph.components.GenericStorage(
+            label='storage6',
+            nominal_storage_capacity=45,
+            inputs={bel: solph.Flow(nominal_value=23, variable_costs=10e10)},
+            outputs={bel: solph.Flow(nominal_value=7.5, variable_costs=10e10)},
+            capacity_min=0)
+    with tools.assert_raises_regexp(
+            AttributeError,
+            ("The attribute 'capacity_max' has been renamed to"
+             " 'max_storage_level'")):
+        solph.components.GenericStorage(
+            label='storage7',
+            nominal_storage_capacity=45,
+            inputs={bel: solph.Flow(nominal_value=23, variable_costs=10e10)},
+            outputs={bel: solph.Flow(nominal_value=7.5, variable_costs=10e10)},
+            capacity_max=0)
+    with tools.assert_raises_regexp(
+            AttributeError,
+            ("The attribute 'nominal_capacity' has been renamed to"
+             " 'nominal_storage_capacity'")):
+        solph.components.GenericStorage(
+            label='storage7',
+            nominal_capacity=45,
+            inputs={bel: solph.Flow(nominal_value=23, variable_costs=10e10)},
+            outputs={bel: solph.Flow(nominal_value=7.5, variable_costs=10e10)})
+
+
 # ********* OffsetTransformer *********
 
 def test_offsettransformer_wrong_flow_type():

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -60,55 +60,33 @@ def test_generic_storage_3():
 
 
 def test_generic_storage_with_old_parameters():
-    bel = solph.Bus()
-    with tools.assert_raises_regexp(
-            AttributeError,
-            ("The attribute 'initial_capacity' has been renamed to "
-             "'initial_storage_level'.")):
+    deprecated = {
+        'nominal_capacity': 45,
+        'initial_capacity': 0,
+        'capacity_loss': 0,
+        'capacity_min': 0,
+        'capacity_max': 0,
+    }
+    # Make sure an `AttributeError` is raised if we supply all deprecated
+    # parameters.
+    with tools.assert_raises(AttributeError) as caught:
         solph.components.GenericStorage(
-            label='storage5',
-            nominal_storage_capacity=45,
-            inputs={bel: solph.Flow(nominal_value=23, variable_costs=10e10)},
-            outputs={bel: solph.Flow(nominal_value=7.5, variable_costs=10e10)},
-            initial_capacity=0)
-    with tools.assert_raises_regexp(
+            label='`GenericStorage` with all deprecated parameters',
+            **deprecated
+        )
+    for parameter in deprecated:
+        # Make sure every parameter used is mentioned in the exception's
+        # message.
+        assert parameter in str(caught.exception)
+        # Make sure an `AttributeError` is raised for each deprecated parameter.
+        tools.assert_raises(
             AttributeError,
-            "The attribute 'capacity_loss' has been renamed to 'loss_rate'"):
-        solph.components.GenericStorage(
-            label='storage6',
-            nominal_storage_capacity=45,
-            inputs={bel: solph.Flow(nominal_value=23, variable_costs=10e10)},
-            outputs={bel: solph.Flow(nominal_value=7.5, variable_costs=10e10)},
-            capacity_loss=0)
-    with tools.assert_raises_regexp(
-            AttributeError,
-            ("The attribute 'capacity_min' has been renamed to"
-             " 'min_storage_level'")):
-        solph.components.GenericStorage(
-            label='storage6',
-            nominal_storage_capacity=45,
-            inputs={bel: solph.Flow(nominal_value=23, variable_costs=10e10)},
-            outputs={bel: solph.Flow(nominal_value=7.5, variable_costs=10e10)},
-            capacity_min=0)
-    with tools.assert_raises_regexp(
-            AttributeError,
-            ("The attribute 'capacity_max' has been renamed to"
-             " 'max_storage_level'")):
-        solph.components.GenericStorage(
-            label='storage7',
-            nominal_storage_capacity=45,
-            inputs={bel: solph.Flow(nominal_value=23, variable_costs=10e10)},
-            outputs={bel: solph.Flow(nominal_value=7.5, variable_costs=10e10)},
-            capacity_max=0)
-    with tools.assert_raises_regexp(
-            AttributeError,
-            ("The attribute 'nominal_capacity' has been renamed to"
-             " 'nominal_storage_capacity'")):
-        solph.components.GenericStorage(
-            label='storage7',
-            nominal_capacity=45,
-            inputs={bel: solph.Flow(nominal_value=23, variable_costs=10e10)},
-            outputs={bel: solph.Flow(nominal_value=7.5, variable_costs=10e10)})
+            solph.components.GenericStorage,
+            **{
+                "label": "`GenericStorage` with `{}`".format(parameter),
+                parameter: deprecated[parameter],
+            }
+        )
 
 
 # ********* OffsetTransformer *********


### PR DESCRIPTION
The deprecated attributes will be silently ignored. This may lead to an unwanted behavior if users have updated from v0.2.3 to v0.3.0. The error message will help to avoid problems.

The following Storage will work with v0.2.3 as well as with v0.3.0 but some attributes will be ignored, so that the capacity of the storage at time step 0  will be `None` and not `0` as intended because the parameter `initial_capacity` does not exists in v0.3.0 and therefore will be ignored. The parameter `initial_storage_level` (new name of `initial_capacity`) will be set to the default value, which is `None`.

```python
storage = solph.components.GenericStorage(
    label='storage',
    inputs={bel: solph.Flow()},
    outputs={bel: solph.Flow()},
    capacity_loss=0.5,
    initial_capacity=0,
    invest_relation_input_capacity=1/6,
    invest_relation_output_capacity=1/6,
    inflow_conversion_factor=1,
    outflow_conversion_factor=0.8,
    investment=solph.Investment(ep_costs=epc_storage),
)
```

We could also raise a warning instead of an error but I think this is clearer.

We may release an Hotfix v0.3.1 soon to help people to avoid problems with there models.
