### PR TITLE
Generalise shared limits

### DIFF
--- a/doc/whatsnew/v0-3-1.rst
+++ b/doc/whatsnew/v0-3-1.rst
@@ -1,5 +1,5 @@
 v0.3.1 (September ??, 2019)
-++++++++++++++++++++++++++
++++++++++++++++++++++++++++
 
 
 API changes
@@ -10,7 +10,8 @@ API changes
 New features
 ############
 
-* something
+* Allow generic limits for integral over weighted flows.
+  (This is a generalised version of <solph.constraints.emission_limit>.)
 
 New components
 ##############
@@ -45,4 +46,4 @@ Other changes
 Contributors
 ############
 
-* something
+* Patrik Schönfeldt

--- a/doc/whatsnew/v0-3-2.rst
+++ b/doc/whatsnew/v0-3-2.rst
@@ -46,4 +46,5 @@ Other changes
 Contributors
 ############
 
+* Johannes Röder
 * Patrik Schönfeldt

--- a/doc/whatsnew/v0-3-2.rst
+++ b/doc/whatsnew/v0-3-2.rst
@@ -12,6 +12,7 @@ New features
 
 * Allow generic limits for integral over weighted flows.
   (This is a generalised version of <solph.constraints.emission_limit>.)
+* Allow time-dependent weights for integrated weighted limit.
 
 New components
 ##############

--- a/oemof/solph/constraints.py
+++ b/oemof/solph/constraints.py
@@ -77,7 +77,7 @@ def generic_integral_limit(om, keyword, flows=None, limit=None):
     flows : dict
         Dictionary holding the flows that should be considered in constraint.
         Keys are (source, target) objects of the Flow. If no dictionary is
-        given all flows containing the 'emission_factor' attribute will be
+        given all flows containing the keyword attribute will be
         used.
     keyword : attribute to consider
     limit : numeric
@@ -99,8 +99,8 @@ def generic_integral_limit(om, keyword, flows=None, limit=None):
             if not hasattr(flows[i, o], keyword):
                 raise AttributeError(
                     ('Flow with source: {0} and target: {1} '
-                     'has no attribute emission_factor.').format(i.label,
-                                                                 o.label))
+                     'has no attribute {2}.').format(
+                        i.label, o.label, keyword))
 
     limit_name = "integral_limit_"+keyword
 

--- a/oemof/solph/constraints.py
+++ b/oemof/solph/constraints.py
@@ -88,6 +88,22 @@ def generic_integral_limit(om, keyword, flows=None, limit=None):
     ----
     Flow objects required an attribute named like keyword!
 
+    **Constraint:**
+
+    .. math::
+        \sum_n \sum_t w_n(t) \cdot P_n(t) \cdot \tau(t) \le L \\
+
+    The symbols used are defined as follows
+    (with Variables (V) and Parameters (P)):
+
+    ================ ==== =====================================================
+    math. symbol     type explanation
+    ================ ==== =====================================================
+    :math:`P_n(t)`   V    power flow :math:`n` at time step :math:`t`
+    :math:`w_N(t)`   P    weight given to Flow named according to `keyword`
+    :math:`\tau(t)`  P    width of time step :math:`t`
+    :math:`L`        P    global limit given by keyword `limit`
+
     """
     if flows is None:
         flows = {}
@@ -106,8 +122,9 @@ def generic_integral_limit(om, keyword, flows=None, limit=None):
     limit_name = "integral_limit_"+keyword
 
     setattr(om, limit_name, po.Expression(
-        expr=sum(om.flow[inflow, outflow, t] * om.timeincrement[t] *
-                 sequence(getattr(flows[inflow, outflow], keyword))[t]
+        expr=sum(om.flow[inflow, outflow, t]
+                 * om.timeincrement[t]
+                 * sequence(getattr(flows[inflow, outflow], keyword))[t]
                  for (inflow, outflow) in flows
                  for t in om.TIMESTEPS)))
 

--- a/oemof/solph/constraints.py
+++ b/oemof/solph/constraints.py
@@ -68,8 +68,8 @@ def generic_integral_limit(om, keyword, flows=None, limit=None):
     With `F_I` being the set of flows considered for the integral limit and
     `T` being the set of time steps.
 
-    Total total emissions after optimization can be retrieved calling the
-    :attr:`om.oemof.solph.Model.integral_limit_${keyword}()`.
+    Total value of keyword attributes after optimization can be retrieved
+    calling the :attr:`om.oemof.solph.Model.integral_limit_${keyword}()`.
 
     Parameters
     ----------
@@ -82,7 +82,7 @@ def generic_integral_limit(om, keyword, flows=None, limit=None):
         used.
     keyword : attribute to consider
     limit : numeric
-        Absolute emission limit for the energy system.
+        Absolute limit of keyword attribute for the energy system.
 
     Note
     ----

--- a/oemof/solph/constraints.py
+++ b/oemof/solph/constraints.py
@@ -9,6 +9,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 """
 
 import pyomo.environ as po
+from oemof.solph.plumbing import sequence
 
 
 def investment_limit(model, limit=None):
@@ -106,7 +107,7 @@ def generic_integral_limit(om, keyword, flows=None, limit=None):
 
     setattr(om, limit_name, po.Expression(
         expr=sum(om.flow[inflow, outflow, t] * om.timeincrement[t] *
-                 getattr(flows[inflow, outflow], keyword)
+                 sequence(getattr(flows[inflow, outflow], keyword))[t]
                  for (inflow, outflow) in flows
                  for t in om.TIMESTEPS)))
 

--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -498,9 +498,9 @@ class Constraint_Tests:
         bel = solph.Bus(label='electricityBus')
 
         solph.Source(label='source1', outputs={bel: solph.Flow(
-            nominal_value=100, emission_factor=0.5)})
+            nominal_value=100, emission_factor=[0.5, -1.0, 2.0])})
         solph.Source(label='source2', outputs={bel: solph.Flow(
-            nominal_value=100, emission_factor=0.8)})
+            nominal_value=100, emission_factor=3.5)})
 
         # Should be ignored because the emission attribute is not defined.
         solph.Source(label='source3', outputs={bel: solph.Flow(

--- a/tests/lp_files/emission_limit.lp
+++ b/tests/lp_files/emission_limit.lp
@@ -6,7 +6,7 @@ objective:
 
 s.t.
 
-c_u_emission_limit_:
+c_u_integral_limit_emission_factor_constraint_:
 +0.5 flow(source1_electricityBus_0)
 +0.5 flow(source1_electricityBus_1)
 +0.5 flow(source1_electricityBus_2)

--- a/tests/lp_files/emission_limit.lp
+++ b/tests/lp_files/emission_limit.lp
@@ -8,11 +8,11 @@ s.t.
 
 c_u_integral_limit_emission_factor_constraint_:
 +0.5 flow(source1_electricityBus_0)
-+0.5 flow(source1_electricityBus_1)
-+0.5 flow(source1_electricityBus_2)
-+0.80000000000000004 flow(source2_electricityBus_0)
-+0.80000000000000004 flow(source2_electricityBus_1)
-+0.80000000000000004 flow(source2_electricityBus_2)
+-1 flow(source1_electricityBus_1)
++2 flow(source1_electricityBus_2)
++3.5 flow(source2_electricityBus_0)
++3.5 flow(source2_electricityBus_1)
++3.5 flow(source2_electricityBus_2)
 <= 777
 
 c_e_Bus_balance(electricityBus_0)_:


### PR DESCRIPTION
This PR implements a generalised version of "emission_limit", as suggested in #585. As this type of limit implements weighted integrals over the flows, I called it `generic_integral_limit`.

Note that `investment_limit` handles `Flow`s as well as `GenericInvestmentStorage`, so it needs a different treatment. It might be possible to incorporate all of these into one creator function for global limit constraints, but that would then need to work on `Node`s instead of specialised implementations.