### PR TITLE
Add generic limit to investment flows

### DIFF
--- a/oemof/solph/constraints.py
+++ b/oemof/solph/constraints.py
@@ -64,7 +64,9 @@ def generic_investment_limit(model, keyword, limit=None):
     The Investment attribute of the considered (Investment-)flows requires an
     attribute named like keyword!
 
-    **Constraint:**
+
+    Constraint
+    ----------
 
     .. math:: \sum_{i \in IF}  P_i \cdot w_i \leq limit
 

--- a/oemof/solph/options.py
+++ b/oemof/solph/options.py
@@ -28,11 +28,17 @@ class Investment:
 
     """
     def __init__(self, maximum=float('+inf'), minimum=0, ep_costs=0,
-                 existing=0):
+                 existing=0, **kwargs):
         self.maximum = maximum
         self.minimum = minimum
         self.ep_costs = ep_costs
         self.existing = existing
+
+        keys = [k for k in kwargs]
+
+        for attribute in set(keys):
+            value = kwargs.get(attribute)
+            setattr(self, attribute, value)
 
 
 class NonConvex:


### PR DESCRIPTION
Analog to the general formulation of a constraint function for flows (generalization of co2 limit #602 ), there was the idea of providing an option of putting attributes to investments, which are limited. (e.g. different investments need some further resources which are limited). Maybe #585 was ment for discussing that as well, at least there was a discussion at the dev meeting about that functionality.
This features requires a modification of the `Investment` class in `option.py` - is there something we need to consider at this point?
 
What do you think about that generally? And could you give me a feedback about the implementation? It is very close to `generic_integral_limit`.

- [ ] tests
- [ ] documentation