### PR TITLE
Improve dependency integration in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ matrix:
     - python: 3.6
     - python: 3.7
       dist: xenial
-      sudo: true
 
-# command to install dependencies
-before_install:
-  - sudo apt-get install coinor-cbc
+addons:
+  apt:
+    packages:
+      - coinor-cbc
 
 install:
   - pip install .[datapackage]
@@ -22,3 +22,4 @@ script:
 
 after_success:
   - coveralls
+


### PR DESCRIPTION
This is just an improvement to the TravisCI pipeline, that will hopefully prevent errors like the one mentioned in https://github.com/oemof/oemof/pull/632#issuecomment-542277361.

Background: Before this PR, sudo was used to explicitly call "apt-get install coinor-cbc". However, Travis has an own API to tell the CI pipeline which dependencies have to be installed. Using this officially supported way will hopefully prevent failures when installing cbc.