### PR TITLE
Features/docs improve sequence data type

### DIFF
--- a/doc/whatsnew/v0-4-0.rst
+++ b/doc/whatsnew/v0-4-0.rst
@@ -46,8 +46,12 @@ Other changes
 
 * The ``loss_rate`` of :class:`~oemof.solph.components.GenericStorage`
     is now defined per time increment.
+* The parameters' data type in the docstrings is changed from
+  `numeric (sequence or scalar)` to `numeric (iterable or scalar)`
+  (`Issue #673 <https://github.com/oemof/oemof/issues/673>`_).
 
 Contributors
 ############
 
 * Caterina Köhl
+* Jonathan Amme

--- a/oemof/network.py
+++ b/oemof/network.py
@@ -235,6 +235,8 @@ class Node:
 
 
 EdgeLabel = NT("EdgeLabel", ['input', 'output'])
+
+
 class Edge(Node):
     """ :class:`Bus`es/:class:`Component`s are always connected by an :class:`Edge`.
 

--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -58,7 +58,7 @@ class GenericStorage(network.Transformer):
 
     initial_storage_level : numeric
         The content of the storage in the first time step of optimization.
-    balanced : boolian
+    balanced : boolean
         Couple storage level of first and last time step.
         (Total inflow and total outflow are balanced.)
     loss_rate : numeric (iterable or scalar)

--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -61,18 +61,18 @@ class GenericStorage(network.Transformer):
     balanced : boolian
         Couple storage level of first and last time step.
         (Total inflow and total outflow are balanced.)
-    loss_rate : numeric (sequence or scalar)
+    loss_rate : numeric (iterable or scalar)
         The relative loss of the storage capacity per timeunit.
-    inflow_conversion_factor : numeric (sequence or scalar)
+    inflow_conversion_factor : numeric (iterable or scalar)
         The relative conversion factor, i.e. efficiency associated with the
         inflow of the storage.
-    outflow_conversion_factor : numeric (sequence or scalar)
+    outflow_conversion_factor : numeric (iterable or scalar)
         see: inflow_conversion_factor
-    min_storage_level : numeric (sequence or scalar)
+    min_storage_level : numeric (iterable or scalar)
         The minimum storaged energy of the storage as fraction of the
         nominal storage capacity (between 0 and 1).
         To set different values in every time step use a sequence.
-    max_storage_level : numeric (sequence or scalar)
+    max_storage_level : numeric (iterable or scalar)
         see: min_storage_level
     investment : :class:`oemof.solph.options.Investment` object
         Object indicating if a nominal_value of the flow is determined by

--- a/oemof/solph/custom.py
+++ b/oemof/solph/custom.py
@@ -195,7 +195,7 @@ class Link(Transformer):
     conversion_factors : dict
         Dictionary containing conversion factors for conversion of each flow.
         Keys are the connected tuples (input, output) bus objects.
-        The dictionary values can either be a scalar or a sequence with length
+        The dictionary values can either be a scalar or an iterable with length
         of time horizon for simulation.
 
     Note: This component is experimental. Use it with care.

--- a/oemof/solph/network.py
+++ b/oemof/solph/network.py
@@ -51,7 +51,7 @@ class Flow(on.Edge):
 
     Keyword arguments are used to set the attributes of this flow. Parameters
     which are handled specially are noted below.
-    For the case where a parameter can be either a scalar or a sequence, a
+    For the case where a parameter can be either a scalar or an iterable, a
     scalar value will be converted to a sequence containing the scalar value at
     every index. This sequence is then stored under the paramter's key.
 
@@ -61,12 +61,12 @@ class Flow(on.Edge):
         The nominal value of the flow. If this value is set the corresponding
         optimization variable of the flow object will be bounded by this value
         multiplied with min(lower bound)/max(upper bound).
-    max : numeric (sequence or scalar)
+    max : numeric (iterable or scalar)
         Normed maximum value of the flow. The flow absolute maximum will be
         calculated by multiplying :attr:`nominal_value` with :attr:`max`
-    min : numeric (sequence or scalar)
+    min : numeric (iterable or scalar)
         Nominal minimum value of the flow (see :attr:`max`).
-    actual_value : numeric (sequence or scalar)
+    actual_value : numeric (iterable or scalar)
         Specific value for the flow variable. Will be multiplied with the
         :attr:`nominal_value` to get the absolute value. If :attr:`fixed` is
         set to :obj:`True` the flow variable will be fixed to :py:`actual_value
@@ -74,7 +74,7 @@ class Flow(on.Edge):
     positive_gradient : :obj:`dict`, default: :py:`{'ub': None, 'costs': 0}`
         A dictionary containing the following two keys:
 
-         * :py:`'ub'`: numeric (sequence, scalar or None), the normed *upper
+         * :py:`'ub'`: numeric (iterable, scalar or None), the normed *upper
            bound* on the positive difference (:py:`flow[t-1] < flow[t]`) of
            two consecutive flow values.
          * :py:`'costs``: numeric (scalar or None), the gradient cost per
@@ -84,7 +84,7 @@ class Flow(on.Edge):
 
         A dictionary containing the following two keys:
 
-          * :py:`'ub'`: numeric (sequence, scalar or None), the normed *upper
+          * :py:`'ub'`: numeric (iterable, scalar or None), the normed *upper
             bound* on the negative difference (:py:`flow[t-1] > flow[t]`) of
             two consecutive flow values.
           * :py:`'costs``: numeric (scalar or None), the gradient cost per
@@ -95,7 +95,7 @@ class Flow(on.Edge):
         with the nominal_value to get the absolute limit.
     summed_min : numeric
         see above
-    variable_costs : numeric (sequence or scalar)
+    variable_costs : numeric (iterable or scalar)
         The costs associated with one unit of the flow. If this is set the
         costs will be added to the objective expression of the optimization
         problem.
@@ -232,7 +232,7 @@ class Transformer(on.Transformer):
     conversion_factors : dict
         Dictionary containing conversion factors for conversion of each flow.
         Keys are the connected bus objects.
-        The dictionary values can either be a scalar or a sequence with length
+        The dictionary values can either be a scalar or an iterable with length
         of time horizon for simulation.
 
     Examples

--- a/oemof/solph/options.py
+++ b/oemof/solph/options.py
@@ -39,11 +39,11 @@ class NonConvex:
     """
     Parameters
     ----------
-    startup_costs : numeric (sequence or scalar)
+    startup_costs : numeric (iterable or scalar)
         Costs associated with a start of the flow (representing a unit).
-    shutdown_costs : numeric (sequence or scalar)
+    shutdown_costs : numeric (iterable or scalar)
         Costs associated with the shutdown of the flow (representing a unit).
-    activity_costs : numeric (sequence or scalar)
+    activity_costs : numeric (iterable or scalar)
         Costs associated with the active operation of the flow, independently
         from the actual output.
     minimum_uptime : numeric (1 or positive integer)

--- a/oemof/solph/plumbing.py
+++ b/oemof/solph/plumbing.py
@@ -20,7 +20,7 @@ def sequence(iterable_or_scalar):
 
     Parameters
     ----------
-    iterable_or_scalar : array-like, None, int, float
+    iterable_or_scalar : iterable, None, int, float
 
     Examples
     --------

--- a/oemof/solph/plumbing.py
+++ b/oemof/solph/plumbing.py
@@ -13,14 +13,14 @@ from collections import abc, UserList
 from itertools import repeat
 
 
-def sequence(sequence_or_scalar):
-    """ Tests if an object is sequence (except string) or scalar and returns
-    a the original sequence if object is a sequence and a 'emulated' sequence
+def sequence(iterable_or_scalar):
+    """ Tests if an object is iterable (except string) or scalar and returns
+    a the original sequence if object is an iterable and a 'emulated' sequence
     object of class _Sequence if object is a scalar or string.
 
     Parameters
     ----------
-    sequence_or_scalar : array-like, None, int, float
+    iterable_or_scalar : array-like, None, int, float
 
     Examples
     --------
@@ -37,11 +37,11 @@ def sequence(sequence_or_scalar):
     [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10]
 
     """
-    if (isinstance(sequence_or_scalar, abc.Iterable) and not
-            isinstance(sequence_or_scalar, str)):
-        return sequence_or_scalar
+    if (isinstance(iterable_or_scalar, abc.Iterable) and not
+            isinstance(iterable_or_scalar, str)):
+        return iterable_or_scalar
     else:
-        return _Sequence(default=sequence_or_scalar)
+        return _Sequence(default=iterable_or_scalar)
 
 
 class _Sequence(UserList):


### PR DESCRIPTION
The parameters' data type in the docstrings is changed from `numeric (sequence or scalar)` to `numeric (iterable or scalar)`, closes #673.

Beside the docstrings, I also adapted the param name of the function `sequence()` in 043a02b3e2c0045d2cdf9a1fb197e6ad87a56911. This is an API change, right? Should I include this too in the API changes list in what's new? (actually this param renaming is more a cosmetic matter, not actually needed) 

**EDIT:** The API change disallows this PR to be included in v0.3.3, is this correct? I assume v0.4.0 is the target then. Do I have to use `dev` or `0.4` (does not exist yet) as base?