### PR TITLE
Fix docstring formulas

### DIFF
--- a/doc/api/oemof.tools.rst
+++ b/doc/api/oemof.tools.rst
@@ -37,7 +37,7 @@ oemof.tools.logger module
     :show-inheritance:
 
 oemof.tools.debugging module
--------------------------
+----------------------------
 
 .. automodule:: oemof.tools.debugging
     :members:

--- a/oemof/tools/economics.py
+++ b/oemof/tools/economics.py
@@ -11,8 +11,8 @@ SPDX-License-Identifier: MIT
 
 
 def annuity(capex, n, wacc, u=None, cost_decrease=0):
-    r"""Calculates the annuity of an initial investment 'capex', considering the
-    cost of capital 'wacc' during a project horizon 'n'
+    r"""Calculates the annuity of an initial investment 'capex', considering
+    the cost of capital 'wacc' during a project horizon 'n'
 
     In case of a single initial investment, the employed formula reads:
 
@@ -25,7 +25,8 @@ def annuity(capex, n, wacc, u=None, cost_decrease=0):
     'u', the formula yields:
 
     .. math::
-        \text{annuity} = \text{capex} \cdot \frac{(\text{wacc} \cdot (1+\text{wacc})^n)}
+        \text{annuity} = \text{capex} \cdot
+                  \frac{(\text{wacc} \cdot (1+\text{wacc})^n)}
                   {((1 + \text{wacc})^n - 1)} \cdot \left(
                   \frac{1 - \left( \frac{(1-cost\_decrease)}
                   {(1+\text{wacc})} \right)^n}

--- a/oemof/tools/economics.py
+++ b/oemof/tools/economics.py
@@ -28,9 +28,9 @@ def annuity(capex, n, wacc, u=None, cost_decrease=0):
         \text{annuity} = \text{capex} \cdot
                   \frac{(\text{wacc} \cdot (1+\text{wacc})^n)}
                   {((1 + \text{wacc})^n - 1)} \cdot \left(
-                  \frac{1 - \left( \frac{(1-cost\_decrease)}
+                  \frac{1 - \left( \frac{(1-\text{cost\_decrease})}
                   {(1+\text{wacc})} \right)^n}
-                  {1 - \left( \frac{(1-cost\_decrease)}{(1+\text{wacc})}
+                  {1 - \left(\frac{(1-\text{cost\_decrease})}{(1+\text{wacc})}
                   \right)^u} \right)
 
     Parameters

--- a/oemof/tools/economics.py
+++ b/oemof/tools/economics.py
@@ -11,25 +11,26 @@ SPDX-License-Identifier: MIT
 
 
 def annuity(capex, n, wacc, u=None, cost_decrease=0):
-    """Calculates the annuity of an initial investment 'capex', considering the
+    r"""Calculates the annuity of an initial investment 'capex', considering the
     cost of capital 'wacc' during a project horizon 'n'
 
     In case of a single initial investment, the employed formula reads:
 
     .. math::
-    annuity = capex \cdot \frac{(wacc \cdot (1+wacc)^n)}
-              {((1 + wacc)^n - 1)}
+        \text{annuity} = \text{capex} \cdot
+            \frac{(\text{wacc} \cdot (1+\text{wacc})^n)}
+            {((1 + \text{wacc})^n - 1)}
 
     In case of repeated investments (due to replacements) at fixed intervals
     'u', the formula yields:
 
     .. math::
-    annuity = capex \cdot \frac{(wacc \cdot (1+wacc)^n)}
-              {((1 + wacc)^n - 1)} \cdot \left(
-              \frac{1 - \left( \frac{(1-cost\_decrease)}
-              {(1+wacc)} \right)^n}
-              {1 - \left( \frac{(1-cost\_decrease)}{(1+wacc)}
-              \right)^u} \right)
+        \text{annuity} = \text{capex} \cdot \frac{(\text{wacc} \cdot (1+\text{wacc})^n)}
+                  {((1 + \text{wacc})^n - 1)} \cdot \left(
+                  \frac{1 - \left( \frac{(1-cost\_decrease)}
+                  {(1+\text{wacc})} \right)^n}
+                  {1 - \left( \frac{(1-cost\_decrease)}{(1+\text{wacc})}
+                  \right)^u} \right)
 
     Parameters
     ----------


### PR DESCRIPTION
Fixes the docstring of oemof.tools.economics.annuity, which has a bug. The formulas are not shown correctly (#688).

Insights: The r in front of the docstring was missing. Also indented the formulas and wrapped the variables described in words with a latex \text{}.