### PR TITLE
Fixing README.rst and adapting it to also serve as an Overview in readthedocs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,6 @@
-=======================================
-Open Energy Modelling Framework (oemof)
-=======================================
-
+=================================================
+Overview: Open Energy Modelling Framework (oemof)
+=================================================
 .. start-badges
 
 .. list-table::

--- a/README.rst
+++ b/README.rst
@@ -62,11 +62,11 @@ Open Energy Modelling Framework (oemof)
 The Open Energy Modelling Framework (oemof) is a Python toolbox for energy system modelling and optimisation.
 
 The oemof project aims to be a loose organisational frame for tools in the wide field of (energy) system modelling.
-Every project is managed by their own developer team but we share some developer and design rules to make it easier to understand each others tools.
+Every project is managed by their own developer team but we share some developer and design rules to make it easier to understand each other's tools.
 
-All projects are in different states and some even may not have a stable release but all projects are open to join.
+All projects are in different stages of implementation, some even may not have a stable release, but all projects are open to be joined by interested people.
 We do not belong to a specific institution and everybody is free to join the developer teams and will have the same rights.
-There is no higher decission level.
+There is no higher decision level.
 
 This repository is also used to organise everything for the oemof community.
 

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-========
-Overview
-========
+=======================================
+Open Energy Modelling Framework (oemof)
+=======================================
 
 .. start-badges
 
@@ -59,7 +59,7 @@ Overview
 
 .. end-badges
 
-Open Energy Modelling Framework - Python toolbox for energy system modelling and optimisation.
+The Open Energy Modelling Framework (oemof) is a Python toolbox for energy system modelling and optimisation.
 
 The oemof project aims to be a loose organisational frame for tools in the wide field of (energy) system modelling.
 Every project is managed by their own developer team but we share some developer and design rules to make it easier to understand each others tools.

--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ This repository is also used to organise everything for the oemof community.
 - General communication
 
 
-**Content**
+**Overview**
 
 .. contents::
     :depth: 3

--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,8 @@ All projects are in different stages of implementation, some even may not have a
 We do not belong to a specific institution and everybody is free to join the developer teams and will have the same rights.
 There is no higher decision level.
 
-This repository is also used to organise everything for the oemof community.
+
+`This repository <https://github.com/oemof/oemof>`_ is also used to organise everything for the oemof community.
 
 - Webconference dates
 - Real life meetings

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,7 @@ This repository is also used to organise everything for the oemof community.
 - Website and Mailinglist
 - General communication
 
+You can find recent topics of discussion in the `issues <https://github.com/oemof/oemof/issues>`_.
 
 **Overview**
 

--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ Overview
 
 Open Energy Modelling Framework - Python toolbox for energy system modelling and optimisation.
 
-The omeof project aims to be a loose organisational frame for tools in the wide field of (energy) system modelling.
+The oemof project aims to be a loose organisational frame for tools in the wide field of (energy) system modelling.
 Every project is managed by their own developer team but we share some developer and design rules to make it easier to understand each others tools.
 
 All projects are in different states and some even may not have a stable release but all projects are open to join.

--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ Overview: Open Energy Modelling Framework (oemof)
 The Open Energy Modelling Framework (oemof) is a Python toolbox for energy system modelling and optimisation.
 
 The oemof project aims to be a loose organisational frame for tools in the wide field of (energy) system modelling.
-Every project is managed by their own developer team but we share some developer and design rules to make it easier to understand each other's tools.
+Every project is managed by their own developer team but we share some developer and design rules to make it easier to understand each other's tools. All project libraries are free software licenced under the MIT license.
 
 All projects are in different stages of implementation, some even may not have a stable release, but all projects are open to be joined by interested people.
 We do not belong to a specific institution and everybody is free to join the developer teams and will have the same rights.
@@ -136,11 +136,6 @@ Projects in an early state
 
 * `DHNx <https://github.com/oemof/dhnx>`_
    District heating system optimisation and simulation models
-
-
-
-All project libraries are free software licenced under the MIT license.
-
 
 
 Installation


### PR DESCRIPTION
Adresses #69 
Fixes typos while identifing feedback for the new readthedocs structure, here for the Overview (see feedback [here](https://github.com/oemof/oemof/issues/69#issuecomment-626704219)).

Changed: 
* Title of README.rst (easier to understand in readthedocs)
* Fix typos
* Adding some links
* Change where MIT license is mentioned.

I was not sure if I should really change AUTHORS.rst, as here a group is called but NOT individual authors. Also the CHANGELOG.rst did not include anything, so I did not change it either. Both are changes I should have done according to [this](https://oemof.readthedocs.io/en/latest/contributing.html#pull-request-guidelines).