### PR TITLE
Add description of oemof.thermal's usage in oemof's documentation

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -26,7 +26,7 @@ The formulation of the energy system is based on the oemof-network library but c
 `oemof-thermal <https://github.com/oemof/oemof-thermal>`_
 =========================================================
 
-Coming soon...
+`oemof.thermal <https://github.com/oemof/oemof-thermal>`_ is an oemof library with a focus on thermal energy technologies (heating/cooling). In its original intention it is an extension to the components of the optimization framework oemof.solph. However, some of its functions may be useful for their own.
 
 
 `cydets <https://github.com/oemof/cydets>`_


### PR DESCRIPTION
With this PR a description of oemof.thermal's usage is added to the section 'Usage' in oemof's documentation.

Related: Issue https://github.com/oemof/oemof-thermal/issues/119 