### PR TITLE
Add hydropowerlib to list of projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -148,6 +148,9 @@ Projects in an early state
 * `DHNx <https://github.com/oemof/dhnx>`_
    District heating system optimisation and simulation models
 
+* `hydropowerlib <https://github.com/hydro-python/hydropowerlib>`_
+   The hydropowerlib is designed to calculate feedin time series of run-of-the-river hydropower plants.
+
 
 Installation
 ============


### PR DESCRIPTION
I would count the **hydropowerlib** as part of oemof since it is an extension of the _feedinlib_.

> The hydropowerlib is designed to calculate feedin time series of run-of-the-river hydropower plants. The hydropowerlib is an out-take from the feedinlib (hydropower, windpower and pv) to build up a community concentrating on hydropower models.
https://github.com/hydro-python/hydropowerlib

There has not been a stable release yet.