### PR TITLE
Improve formating of "beitragsordnung"

### DIFF
--- a/legal/EN_beitragsordnung.md
+++ b/legal/EN_beitragsordnung.md
@@ -1,9 +1,10 @@
 # Contribution rules
 
 The annual contribution is chosen by the members themselves. However, it amounts to at least
-1.  5 € reduced fee for natural persons, applicable based on information of the member,
-2.  30 € standard fee for natural persons, and
-3.  500 € for institutes and other legal entities.
+
+*   5 € reduced fee for natural persons, applicable based on information of the member,
+*   30 € standard fee for natural persons, and
+*   500 € for institutes and other legal entities.
 
 Each member has to pay the annual contribution at the latest by January 31st of the year.
 

--- a/legal/beitragsordnung.md
+++ b/legal/beitragsordnung.md
@@ -1,9 +1,10 @@
 # Beitragsordnung
 
 Der Jahresbeitrag wird von den Mitgliedern selbst gewählt. Er beträgt jedoch mindestens
-1.  5 € reduzierten Beitrag für natürliche Personen, bei Bedürftigkeit basierend auf Selbstauskunft,
-2.  30 € normalen Beitrag für natürliche Personen  und
-3.  500 € für Institutionen und andere juristische Personen.
+
+*   5 € reduzierten Beitrag für natürliche Personen, bei Bedürftigkeit basierend auf Selbstauskunft,
+*   30 € normalen Beitrag für natürliche Personen  und
+*   500 € für Institutionen und andere juristische Personen.
 
 Jedes Mitglied hat den Jahresbeitrag spätestens bis zum 31. Januar des Jahres
 zu entrichten.


### PR DESCRIPTION
The enumeration was not always rendered (missing blank line). Also, it was source of misunderstandings (e.g. 1.5 €). As letters are not allowed in markdown, I suggest an unnumbered list.