### PR TITLE
Unpin jinja2 in docs/requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 sphinx>=1.3
 sphinx-rtd-theme
-jinja2==3.1.4
+jinja2


### PR DESCRIPTION
The pinned version (3.1.4) has known security issues. Remove the constraint as pinning is bad practice for libraries anyway.